### PR TITLE
Baleen <-> Avro generators

### DIFF
--- a/baleen-avro-generator/README.md
+++ b/baleen-avro-generator/README.md
@@ -1,0 +1,75 @@
+# Baleen Avro Schema Generators
+
+## Goal 1: Support Legacy Avro Schemas
+
+Given legacy Avro schemas, create Baleen data descriptions to do validation.
+
+Create Baleen description files from Avro schemas
+
+```kotlin
+import com.shoprunner.baleen.avro.BaleenEncoder.encodeTo
+
+val parser = Schema.Parser()
+val dogSchemaStr = """
+|{
+|   "type": "record",
+|   "namespace": "com.shoprunner.data.dogs",
+|   "name": "Dog",
+|   "doc": "It's a dog. Ruff Ruff!",
+|   "fields": [
+|        { "name": "name", "type": "string", "doc": "The name of the dog" },
+|        { "name": "legs", "type": ["null", "long", "int"], "default": null, "doc": "The number of legs" }
+|   ]
+|}
+""".trimMargin()
+val dogSchema = parser.parse(dogSchemaStr)
+
+val sourceDir = dogSchema.encodeTo(File("src/main/kotlin"))
+```
+
+This produces working Kotlin Code
+
+```kotlin
+package com.shoprunner.data.dogs
+
+import com.shoprunner.baleen.Baleen
+import com.shoprunner.baleen.DataDescription
+import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.LongType
+import com.shoprunner.baleen.types.StringType
+import com.shoprunner.baleen.types.UnionType
+import kotlin.jvm.JvmStatic
+
+/**
+ * It's a dog. Ruff Ruff! */
+object DogType {
+    @JvmStatic
+    val description: DataDescription =
+            Baleen.describe("Dog", "com.shoprunner.data.dogs", "It's a dog. Ruff Ruff!") {
+                p ->
+                    p.attr(
+                        name = "name",
+                        type = StringType(),
+                        markdownDescription = "The name of the dog",
+                        required = true
+                    )
+                    p.attr(
+                        name = "legs",
+                        type = UnionType(LongType(), IntType()),
+                        markdownDescription = "The number of legs",
+                        required = false
+                    )
+
+            }
+
+}
+``` 
+
+## Goal 2: Generate Avro Schemas from Baleen descriptions
+
+```kotlin
+import com.shoprunner.baleen.avro.AvroEncoder.encodeTo
+
+val sourceDir = File("src/main/avro")
+DogType.description.encodeTo(sourceDir)
+```

--- a/baleen-avro-generator/README.md
+++ b/baleen-avro-generator/README.md
@@ -7,7 +7,7 @@ Given legacy Avro schemas, create Baleen data descriptions to do validation.
 Create Baleen description files from Avro schemas
 
 ```kotlin
-import com.shoprunner.baleen.avro.BaleenEncoder.encodeTo
+import com.shoprunner.baleen.avro.BaleenGenerator.encode
 
 val parser = Schema.Parser()
 val dogSchemaStr = """
@@ -24,7 +24,7 @@ val dogSchemaStr = """
 """.trimMargin()
 val dogSchema = parser.parse(dogSchemaStr)
 
-val sourceDir = dogSchema.encodeTo(File("src/main/kotlin"))
+val sourceDir = encode(dogSchema).writeTo(File("src/main/kotlin"))
 ```
 
 This produces working Kotlin Code
@@ -68,8 +68,9 @@ object DogType {
 ## Goal 2: Generate Avro Schemas from Baleen descriptions
 
 ```kotlin
-import com.shoprunner.baleen.avro.AvroEncoder.encodeTo
+import com.shoprunner.baleen.avro.AvroGenerator.encode
+import com.shoprunner.baleen.avro.AvroGenerator.writeTo
 
 val sourceDir = File("src/main/avro")
-DogType.description.encodeTo(sourceDir)
+encode(DogType.description).writeTo(sourceDir)
 ```

--- a/baleen-avro-generator/build.gradle
+++ b/baleen-avro-generator/build.gradle
@@ -1,6 +1,12 @@
 dependencies {
     compile project(':baleen')
     compile "org.apache.avro:avro:1.8.1"
-    compile group: 'com.julianpeeters', name: 'avrohugger-core_2.11', version: '0.16.0'
+    compile 'com.squareup:kotlinpoet:0.7.0'
+    testCompile "org.jetbrains.kotlin:kotlin-compiler:$kotlin_version"
 }
 
+junitPlatformTest {
+    HashMap map = new HashMap()
+    map.put("GEN_CLASSPATH", configurations.testCompile.files.path.join(":"))
+    environment map
+}

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroEncoder.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroEncoder.kt
@@ -1,39 +1,78 @@
 package com.shoprunner.baleen.avro
 
+import com.shoprunner.baleen.BaleenType
 import com.shoprunner.baleen.DataDescription
+import com.shoprunner.baleen.types.CoercibleType
+import com.shoprunner.baleen.types.BooleanType
+import com.shoprunner.baleen.types.FloatType
+import com.shoprunner.baleen.types.DoubleType
+import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.LongType
+import com.shoprunner.baleen.types.StringType
+import com.shoprunner.baleen.types.StringConstantType
+import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.InstantType
+import com.shoprunner.baleen.types.TimestampMillisType
+import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.OccurrencesType
+import com.shoprunner.baleen.types.UnionType
+import org.apache.avro.JsonProperties
 import org.apache.avro.LogicalTypes
 import org.apache.avro.Schema
-import java.io.PrintStream
+import java.io.File
+import java.nio.file.Path
 
 object AvroEncoder {
 
-    fun getAvroType(dataDescription: DataDescription): Schema {
-        val fields = dataDescription.attrs.map { attr ->
-
-            val type = attr.type
-            val avroType = if (type is DataDescription) {
-                getAvroType(type)
-            } else {
-                val typeName = attr.type.name()
-                when (typeName) {
-                    "date" -> LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT))
-                    "float" -> Schema.create(Schema.Type.FLOAT)
-                    "long" -> Schema.create(Schema.Type.LONG)
-                    "string" -> Schema.create(Schema.Type.STRING)
-                    "timestampMillis" -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
-                    else -> throw Exception("Unknown type: " + typeName)
+    fun getAvroSchema(baleenType: BaleenType): Schema {
+        return when (baleenType) {
+            is DataDescription -> encode(baleenType)
+            is CoercibleType -> getAvroSchema(baleenType.type)
+            is BooleanType -> Schema.create(Schema.Type.BOOLEAN)
+            is FloatType -> Schema.create(Schema.Type.FLOAT)
+            is DoubleType -> Schema.create(Schema.Type.DOUBLE)
+            is IntType -> Schema.create(Schema.Type.INT)
+            is LongType -> Schema.create(Schema.Type.LONG)
+            is StringType -> Schema.create(Schema.Type.STRING)
+            is StringConstantType -> Schema.create(Schema.Type.STRING)
+            is EnumType -> Schema.createEnum(null, null, null, baleenType.enum.toList())
+            is InstantType -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
+            is TimestampMillisType -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
+            /* TODO: More Logical Types */
+            is MapType -> {
+                if (baleenType.keyType !is StringType) throw Exception("Map keys can only be String in Avro")
+                Schema.createMap(getAvroSchema(baleenType.valueType))
+            }
+            is OccurrencesType -> Schema.createArray(getAvroSchema(baleenType.memberType))
+            is UnionType -> {
+                val subTypes = baleenType.types.map(::getAvroSchema).distinct()
+                if (subTypes.size == 1) {
+                    subTypes[0]
+                } else {
+                    Schema.createUnion(subTypes)
                 }
             }
+            else -> throw Exception("Unknown type: " + baleenType::class.simpleName)
+        }
+    }
 
-            val optionalAvroType = if (attr.required) {
-                avroType
+    fun encode(dataDescription: DataDescription): Schema {
+        val fields = dataDescription.attrs.map { attr ->
+
+            val avroSchema = getAvroSchema(attr.type)
+
+            val optionalAvroSchema = if (attr.required) {
+                avroSchema
+            } else if (avroSchema.type != Schema.Type.UNION) {
+                Schema.createUnion(Schema.create(Schema.Type.NULL), avroSchema)
             } else {
-                Schema.createUnion(avroType, Schema.create(Schema.Type.NULL))
+                Schema.createUnion(listOf(Schema.create(Schema.Type.NULL)) + avroSchema.types)
             }
 
-            val field = Schema.Field(attr.name, optionalAvroType, attr.markdownDescription.trim(), null as Any? )
+            val field = Schema.Field(attr.name, optionalAvroSchema, attr.markdownDescription.trim(),
+                    if (attr.required) null else JsonProperties.NULL_VALUE)
 
-            attr.aliases.forEach { x -> field.addAlias(x) }
+            attr.aliases.forEach(field::addAlias)
             field
         }
 
@@ -42,12 +81,23 @@ object AvroEncoder {
                 dataDescription.nameSpace, false, fields)
     }
 
-    fun encode(dataDescription: DataDescription, outputStream: PrintStream) {
+    infix fun DataDescription.encodeTo(directory: File): File {
+        val packageDir = File(directory, this.nameSpace.replace(".", "/"))
+        packageDir.mkdirs()
+        val avroFile = File(packageDir, "${this.name}.avsc")
+        val schema = encode(this)
 
-        // TODO namespace
+        avroFile.writeText(schema.toString(true))
+        return directory
+    }
 
-        val schema = getAvroType(dataDescription)
+    infix fun DataDescription.encodeTo(directory: Path): Path {
+        return this.encodeTo(directory.toFile()).toPath()
+    }
 
-        outputStream.println(schema.toString(true))
+    infix fun DataDescription.encodeTo(out: Appendable): Appendable {
+        val schema = encode(this)
+        out.append(schema.toString(true))
+        return out
     }
 }

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroEncoder.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroEncoder.kt
@@ -21,6 +21,7 @@ import org.apache.avro.LogicalTypes
 import org.apache.avro.Schema
 import java.io.File
 import java.nio.file.Path
+import java.time.Instant
 
 object AvroEncoder {
 
@@ -35,7 +36,7 @@ object AvroEncoder {
             is LongType -> Schema.create(Schema.Type.LONG)
             is StringType -> Schema.create(Schema.Type.STRING)
             is StringConstantType -> Schema.create(Schema.Type.STRING)
-            is EnumType -> Schema.createEnum(null, null, null, baleenType.enum.toList())
+            is EnumType -> Schema.createEnum("GeneratedEnum${Instant.now().toEpochMilli()}", null, null, baleenType.enum.toList())
             is InstantType -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
             is TimestampMillisType -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
             /* TODO: More Logical Types */

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroEncoder.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroEncoder.kt
@@ -21,7 +21,6 @@ import org.apache.avro.LogicalTypes
 import org.apache.avro.Schema
 import java.io.File
 import java.nio.file.Path
-import java.time.Instant
 
 object AvroEncoder {
 
@@ -36,7 +35,7 @@ object AvroEncoder {
             is LongType -> Schema.create(Schema.Type.LONG)
             is StringType -> Schema.create(Schema.Type.STRING)
             is StringConstantType -> Schema.create(Schema.Type.STRING)
-            is EnumType -> Schema.createEnum("GeneratedEnum${Instant.now().toEpochMilli()}", null, null, baleenType.enum.toList())
+            is EnumType -> Schema.createEnum(baleenType.enumName, null, null, baleenType.enum.toList())
             is InstantType -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
             is TimestampMillisType -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
             /* TODO: More Logical Types */

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroGenerator.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroGenerator.kt
@@ -22,7 +22,7 @@ import org.apache.avro.Schema
 import java.io.File
 import java.nio.file.Path
 
-object AvroEncoder {
+object AvroGenerator {
 
     fun getAvroSchema(baleenType: BaleenType): Schema {
         return when (baleenType) {
@@ -81,23 +81,21 @@ object AvroEncoder {
                 dataDescription.nameSpace, false, fields)
     }
 
-    infix fun DataDescription.encodeTo(directory: File): File {
-        val packageDir = File(directory, this.nameSpace.replace(".", "/"))
+    fun Schema.writeTo(directory: File): File {
+        val packageDir = File(directory, this.namespace.replace(".", "/"))
         packageDir.mkdirs()
         val avroFile = File(packageDir, "${this.name}.avsc")
-        val schema = encode(this)
 
-        avroFile.writeText(schema.toString(true))
+        avroFile.writeText(this.toString(true))
         return directory
     }
 
-    infix fun DataDescription.encodeTo(directory: Path): Path {
-        return this.encodeTo(directory.toFile()).toPath()
+    fun Schema.writeTo(directory: Path): Path {
+        return this.writeTo(directory.toFile()).toPath()
     }
 
-    infix fun DataDescription.encodeTo(out: Appendable): Appendable {
-        val schema = encode(this)
-        out.append(schema.toString(true))
+    fun Schema.writeTo(out: Appendable): Appendable {
+        out.append(this.toString(true))
         return out
     }
 }

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/BaleenEncoder.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/BaleenEncoder.kt
@@ -1,0 +1,192 @@
+package com.shoprunner.baleen.avro
+
+import com.shoprunner.baleen.Baleen
+import com.shoprunner.baleen.DataDescription
+import com.shoprunner.baleen.types.BooleanType
+import com.shoprunner.baleen.types.FloatType
+import com.shoprunner.baleen.types.DoubleType
+import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.LongType
+import com.shoprunner.baleen.types.LongCoercibleToInstant
+import com.shoprunner.baleen.types.StringType
+import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.OccurrencesType
+import com.shoprunner.baleen.types.UnionType
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.FileSpec
+import org.apache.avro.Schema
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * Given a parsed Avro Schema, generate basic Baleen descriptions.
+ */
+object BaleenEncoder {
+
+    fun processSchema(schema: Schema): TypeSpec {
+        val attrsCodeBlock = schema.fields.map(::processField)
+                .fold(CodeBlock.builder(), { b, c -> b.add(c).add("\n") })
+                .build()
+
+        val modelCodeBlock = CodeBlock.builder()
+                .beginControlFlow("%T.%L(%S, %S, %S)",
+                        Baleen::class,
+                        Baleen::describe.name,
+                        schema.name,
+                        schema.namespace,
+                        schema.doc)
+                .add("p ->\n")
+                .indent()
+                .add(attrsCodeBlock)
+                .add("\n")
+                .unindent()
+                .endControlFlow()
+                .build()
+        return TypeSpec.objectBuilder(ClassName(schema.namespace, "${schema.name}Type"))
+                .addKdoc(schema.doc)
+                .addProperty(PropertySpec.builder("description", DataDescription::class)
+                        .addModifiers(KModifier.PUBLIC)
+                        .addAnnotation(JvmStatic::class)
+                        .initializer(modelCodeBlock)
+                        .build())
+                .build()
+    }
+
+    fun processField(field: Schema.Field): CodeBlock {
+        /*
+        fun attr(
+            name: String,
+            type: BaleenType,
+            markdownDescription: String = "",
+            aliases: Array<String> = arrayOf(),
+            required: Boolean = false
+        )
+         */
+        val isRequired = field.schema().type != Schema.Type.UNION ||
+                field.schema().types.none { it.type == Schema.Type.NULL }
+
+        return CodeBlock.builder().apply {
+            // create attribute
+            add("p.%L(\n", DataDescription::attr.name)
+            indent()
+            // name
+            add("%L = %S,\n", DataDescription::attr.parameters[1].name, field.name())
+            // type
+            add("%L = ", DataDescription::attr.parameters[2].name)
+            add(avroTypeToBaleenType(field.schema()))
+            add(",\n")
+            // markdownDescription
+            add("%L = %S,\n", DataDescription::attr.parameters[3].name, field.doc())
+            // aliases
+            if (field.aliases().isNotEmpty()) {
+                add("%L = %L,\n", DataDescription::attr.parameters[4].name,
+                        field.aliases().joinToString(", ", prefix = "arrayOf(\"", postfix = "\")"))
+            }
+            // required
+            add("%L = %L\n", DataDescription::attr.parameters[5].name, isRequired)
+            unindent()
+            add(")")
+        }.build()
+    }
+
+    fun avroTypeToBaleenType(schema: Schema): CodeBlock {
+        return when (schema.type) {
+            Schema.Type.ARRAY -> {
+                CodeBlock.builder()
+                        .add("%T(", OccurrencesType::class)
+                        .add(avroTypeToBaleenType(schema.elementType))
+                        .add(")")
+                        .build()
+            }
+            Schema.Type.MAP -> {
+                CodeBlock.builder()
+                        .add("%T(%T(), ", MapType::class, StringType::class)
+                        .add(avroTypeToBaleenType(schema.valueType))
+                        .add(")")
+                        .build()
+            }
+            Schema.Type.BOOLEAN -> CodeBlock.of("%T()", BooleanType::class)
+            Schema.Type.STRING -> CodeBlock.of("%T()", StringType::class)
+            Schema.Type.DOUBLE -> CodeBlock.of("%T()", DoubleType::class)
+            Schema.Type.FLOAT -> CodeBlock.of("%T()", FloatType::class)
+            Schema.Type.ENUM -> {
+                val enumCode = CodeBlock.builder().add("%T(", EnumType::class)
+                schema.enumSymbols.forEachIndexed { i, e ->
+                    if (i == 0) {
+                        enumCode.add(CodeBlock.of("%S", e))
+                    } else {
+                        enumCode.add(", ").add(CodeBlock.of("%S", e))
+                    }
+                }
+                enumCode.add(")").build()
+            }
+            Schema.Type.INT -> {
+                /* TODO: Handle more logical types
+                if(schema.logicalType != null) {
+                    when(schema.logicalType.name){
+                        "date" -> CodeBlock.of("%T()", ?::class)
+                        "time-millis" -> CodeBlock.of("%T()", ?::class)
+                        else -> CodeBlock.of("%T()", IntType::class)
+                    }
+                }
+                else */
+                CodeBlock.of("%T()", IntType::class)
+            }
+            Schema.Type.LONG -> {
+                if (schema.logicalType != null) {
+                    when (schema.logicalType.name) {
+                        "timestamp-millis" -> CodeBlock.of("%T()", LongCoercibleToInstant::class)
+                    // TODO: Handle more logical types
+                    //"timestamp-micros" -> CodeBlock.of("%T()", ?::class)
+                    //"time-micros" -> CodeBlock.of("%T()", ?::class)
+                        else -> CodeBlock.of("%T()", LongType::class)
+                    }
+                } else CodeBlock.of("%T()", LongType::class)
+            }
+            Schema.Type.RECORD -> CodeBlock.of("${schema.namespace}.${schema.name}Type.description")
+            Schema.Type.UNION -> {
+                val unionedTypes = schema.types.filterNot { it.type == Schema.Type.NULL }.map { avroTypeToBaleenType(it) }
+                if (unionedTypes.size > 1) {
+                    val builder = CodeBlock.builder().add("%T(", UnionType::class)
+                    unionedTypes.forEachIndexed { i, t ->
+                        if (i == 0) {
+                            builder.add(t)
+                        } else {
+                            builder.add(", ").add(t)
+                        }
+                    }
+                    builder.add(")").build()
+                } else {
+                    unionedTypes.first()
+                }
+            }
+            else -> throw IllegalArgumentException("avro type ${schema.type} not supported")
+        }
+    }
+
+    fun encode(schema: Schema): FileSpec {
+        return FileSpec.builder(schema.namespace, "${schema.name}Type")
+                .addType(processSchema(schema))
+                .build()
+    }
+
+    infix fun Schema.encodeTo(directory: File): File {
+        encode(this).writeTo(directory)
+        return directory
+    }
+
+    infix fun Schema.encodeTo(directory: Path): Path {
+        encode(this).writeTo(directory)
+        return directory
+    }
+
+    infix fun Schema.encodeTo(out: Appendable): Appendable {
+        encode(this).writeTo(out)
+        return out
+    }
+}

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/BaleenEncoder.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/BaleenEncoder.kt
@@ -8,6 +8,7 @@ import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.IntType
 import com.shoprunner.baleen.types.LongType
 import com.shoprunner.baleen.types.LongCoercibleToInstant
+import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.StringType
 import com.shoprunner.baleen.types.EnumType
 import com.shoprunner.baleen.types.MapType
@@ -140,7 +141,7 @@ object BaleenEncoder {
             Schema.Type.LONG -> {
                 if (schema.logicalType != null) {
                     when (schema.logicalType.name) {
-                        "timestamp-millis" -> CodeBlock.of("%T()", LongCoercibleToInstant::class)
+                        "timestamp-millis" -> CodeBlock.of("%T(%T())", LongCoercibleToInstant::class, InstantType::class)
                     // TODO: Handle more logical types
                     // "timestamp-micros" -> CodeBlock.of("%T()", ?::class)
                     // "time-micros" -> CodeBlock.of("%T()", ?::class)

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/BaleenEncoder.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/BaleenEncoder.kt
@@ -142,8 +142,8 @@ object BaleenEncoder {
                     when (schema.logicalType.name) {
                         "timestamp-millis" -> CodeBlock.of("%T()", LongCoercibleToInstant::class)
                     // TODO: Handle more logical types
-                    //"timestamp-micros" -> CodeBlock.of("%T()", ?::class)
-                    //"time-micros" -> CodeBlock.of("%T()", ?::class)
+                    // "timestamp-micros" -> CodeBlock.of("%T()", ?::class)
+                    // "time-micros" -> CodeBlock.of("%T()", ?::class)
                         else -> CodeBlock.of("%T()", LongType::class)
                     }
                 } else CodeBlock.of("%T()", LongType::class)

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/BaleenGenerator.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/BaleenGenerator.kt
@@ -21,13 +21,11 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.FileSpec
 import org.apache.avro.Schema
-import java.io.File
-import java.nio.file.Path
 
 /**
  * Given a parsed Avro Schema, generate basic Baleen descriptions.
  */
-object BaleenEncoder {
+object BaleenGenerator {
 
     fun processSchema(schema: Schema): TypeSpec {
         val attrsCodeBlock = schema.fields.map(::processField)
@@ -174,20 +172,5 @@ object BaleenEncoder {
         return FileSpec.builder(schema.namespace, "${schema.name}Type")
                 .addType(processSchema(schema))
                 .build()
-    }
-
-    infix fun Schema.encodeTo(directory: File): File {
-        encode(this).writeTo(directory)
-        return directory
-    }
-
-    infix fun Schema.encodeTo(directory: Path): Path {
-        encode(this).writeTo(directory)
-        return directory
-    }
-
-    infix fun Schema.encodeTo(out: Appendable): Appendable {
-        encode(this).writeTo(out)
-        return out
     }
 }

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroEncoderTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroEncoderTest.kt
@@ -1,14 +1,29 @@
 package com.shoprunner.baleen.avro
 
 import com.shoprunner.baleen.Baleen
-import com.shoprunner.baleen.types.StringType
-import com.shoprunner.baleen.types.LongType
-import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationResult
+import com.shoprunner.baleen.avro.AvroEncoder.encodeTo
 import com.shoprunner.baleen.types.UnionType
 import com.shoprunner.baleen.types.OccurrencesType
-import com.shoprunner.baleen.avro.AvroEncoder.encodeTo
+import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.StringType
+import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.TimestampMillisType
+import com.shoprunner.baleen.types.InstantType
+import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.FloatType
+import com.shoprunner.baleen.types.BooleanType
+import com.shoprunner.baleen.types.StringCoercibleToFloat
+import com.shoprunner.baleen.types.LongType
+import com.shoprunner.baleen.types.DoubleType
+import com.shoprunner.baleen.types.StringConstantType
+import org.apache.avro.LogicalTypes
+import org.apache.avro.Schema
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -22,8 +37,120 @@ class AvroEncoderTest {
     @Nested
     inner class Types {
         @Test
-        fun `TODO write tests`() {
-            // TODO
+        fun `getAvroSchema encodes the resulting coerced type`() {
+            val schema = AvroEncoder.getAvroSchema(StringCoercibleToFloat(FloatType()))
+            assertThat(schema.type).isEqualTo(Schema.Type.FLOAT)
+        }
+
+        @Test
+        fun `getAvroSchema encodes boolean type`() {
+            val schema = AvroEncoder.getAvroSchema(BooleanType())
+            assertThat(schema.type).isEqualTo(Schema.Type.BOOLEAN)
+        }
+
+        @Test
+        fun `getAvroSchema encodes float type`() {
+            val schema = AvroEncoder.getAvroSchema(FloatType())
+            assertThat(schema.type).isEqualTo(Schema.Type.FLOAT)
+        }
+
+        @Test
+        fun `getAvroSchema encodes double type`() {
+            val schema = AvroEncoder.getAvroSchema(DoubleType())
+            assertThat(schema.type).isEqualTo(Schema.Type.DOUBLE)
+        }
+
+        @Test
+        fun `getAvroSchema encodes int type`() {
+            val schema = AvroEncoder.getAvroSchema(IntType())
+            assertThat(schema.type).isEqualTo(Schema.Type.INT)
+        }
+
+        @Test
+        fun `getAvroSchema encodes long type`() {
+            val schema = AvroEncoder.getAvroSchema(LongType())
+            assertThat(schema.type).isEqualTo(Schema.Type.LONG)
+        }
+
+        @Test
+        fun `getAvroSchema encodes string type`() {
+            val schema = AvroEncoder.getAvroSchema(StringType())
+            assertThat(schema.type).isEqualTo(Schema.Type.STRING)
+        }
+
+        @Test
+        fun `getAvroSchema encodes string constant type`() {
+            val schema = AvroEncoder.getAvroSchema(StringConstantType("abc"))
+            assertThat(schema.type).isEqualTo(Schema.Type.STRING)
+        }
+
+        @Test
+        fun `getAvroSchema encodes enum type`() {
+            val schema = AvroEncoder.getAvroSchema(EnumType("a", "b", "c"))
+            assertThat(schema.type).isEqualTo(Schema.Type.ENUM)
+            assertThat(schema.name).startsWith("GeneratedEnum")
+            assertThat(schema.enumSymbols).containsExactly("a", "b", "c")
+        }
+
+        @Test
+        fun `getAvroSchema encodes instant type`() {
+            val schema = AvroEncoder.getAvroSchema(InstantType())
+            assertThat(schema.type).isEqualTo(Schema.Type.LONG)
+            assertThat(schema.logicalType).isEqualTo(LogicalTypes.timestampMillis())
+        }
+
+        @Test
+        fun `getAvroSchema encodes timestamp-millis type`() {
+            val schema = AvroEncoder.getAvroSchema(TimestampMillisType())
+            assertThat(schema.type).isEqualTo(Schema.Type.LONG)
+            assertThat(schema.logicalType).isEqualTo(LogicalTypes.timestampMillis())
+        }
+
+        @Test
+        fun `getAvroSchema encodes map type`() {
+            val schema = AvroEncoder.getAvroSchema(MapType(StringType(), IntType()))
+            assertThat(schema.type).isEqualTo(Schema.Type.MAP)
+            assertThat(schema.valueType.type).isEqualTo(Schema.Type.INT)
+        }
+
+        @Test
+        fun `getAvroSchema fails map type with non-string key`() {
+            assertThrows(Exception::class.java) {
+                AvroEncoder.getAvroSchema(MapType(IntType(), IntType()))
+            }
+        }
+
+        @Test
+        fun `getAvroSchema encodes occurences type`() {
+            val schema = AvroEncoder.getAvroSchema(OccurrencesType(StringType()))
+            assertThat(schema.type).isEqualTo(Schema.Type.ARRAY)
+            assertThat(schema.elementType.type).isEqualTo(Schema.Type.STRING)
+        }
+
+        @Test
+        fun `getAvroSchema encodes non-nullable union type`() {
+            val schema = AvroEncoder.getAvroSchema(UnionType(IntType(), LongType()))
+            assertThat(schema.type).isEqualTo(Schema.Type.UNION)
+            assertThat(schema.types[0].type).isEqualTo(Schema.Type.INT)
+            assertThat(schema.types[1].type).isEqualTo(Schema.Type.LONG)
+        }
+
+        @Test
+        fun `getAvroSchema encodes union type of one not as a union`() {
+            val schema = AvroEncoder.getAvroSchema(UnionType(IntType()))
+            assertThat(schema.type).isEqualTo(Schema.Type.INT)
+        }
+
+        @Test
+        fun `getAvroSchema fails with an unsupported type`() {
+            class BadType : BaleenType {
+                override fun name() = "bad"
+                override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> = emptySequence()
+            }
+
+            assertThrows(Exception::class.java) {
+                AvroEncoder.getAvroSchema(BadType())
+            }
         }
     }
 

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroEncoderTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroEncoderTest.kt
@@ -2,36 +2,172 @@ package com.shoprunner.baleen.avro
 
 import com.shoprunner.baleen.Baleen
 import com.shoprunner.baleen.types.StringType
+import com.shoprunner.baleen.types.LongType
+import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.UnionType
+import com.shoprunner.baleen.types.OccurrencesType
+import com.shoprunner.baleen.avro.AvroEncoder.encodeTo
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.PrintStream
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AvroEncoderTest {
-    private val dogDescription = Baleen.describe("Dog",
-            markdownDescription = "Type of dog.") { p ->
 
-            p.attr( name = "name",
-                    type = StringType(),
-                    markdownDescription = "Name of the dog.",
-                    required = true)
+    @Nested
+    inner class Types {
+        @Test
+        fun `TODO write tests`() {
+            // TODO
+        }
     }
 
-    @Test
-    fun `simple single attribute`() {
-        val outputStream = ByteArrayOutputStream()
-        AvroEncoder.encode(dogDescription, PrintStream(outputStream))
+    @Nested
+    inner class Models {
+        private val dogDescription = Baleen.describe("Dog", "com.shoprunner.data.dogs", "It's a dog. Ruff Ruff!") { p ->
+            p.attr(
+                    name = "name",
+                    type = StringType(),
+                    markdownDescription = "The name of the dog",
+                    required = true
+            )
+            p.attr(
+                    name = "legs",
+                    type = UnionType(LongType(), IntType()),
+                    markdownDescription = "The number of legs",
+                    required = false
+            )
+        }
 
-        assertThat(outputStream.toString()).isEqualToIgnoringWhitespace("""
-            {
-              "type" : "record",
-              "name" : "Dog",
-              "doc" : "Type of dog.",
-              "fields" : [ {
-                "name" : "name",
-                "type" : "string",
-                "doc" : "Name of the dog."
-              } ]
-            }""")
+        private val packDescription = Baleen.describe("Pack", "com.shoprunner.data.dogs", "It's a Pack of Dogs. Grr Grr!") { p ->
+            p.attr(
+                    name = "name",
+                    type = StringType(),
+                    markdownDescription = "The name of the pack",
+                    aliases = arrayOf("packName"),
+                    required = true
+            )
+            p.attr(
+                    name = "dogs",
+                    type = OccurrencesType(dogDescription),
+                    markdownDescription = "The dogs in the pack",
+                    required = true
+            )
+        }
+
+        private val dogSchemaStr = """
+        |{
+        |   "type": "record",
+        |   "name": "Dog",
+        |   "namespace": "com.shoprunner.data.dogs",
+        |   "doc": "It's a dog. Ruff Ruff!",
+        |   "fields": [
+        |        { "name": "name", "type": "string", "doc": "The name of the dog" },
+        |        { "name": "legs", "type": [ "null", "long", "int" ], "doc": "The number of legs", "default": null }
+        |   ]
+        |}
+        """.trimMargin()
+
+        private val packSchemaByReferenceStr = """
+        |{
+        |   "type": "record",
+        |   "namespace": "com.shoprunner.data.dogs",
+        |   "name": "Pack",
+        |   "doc": "It's a Pack of Dogs. Grr Grr!",
+        |   "fields": [
+        |        { "name": "name", "type": "string", "doc": "The name of the pack", "aliases": [ "packName" ] },
+        |        {
+        |          "name": "dogs",
+        |          "type": {"type": "array", "items": "com.shoprunner.data.dogs.Dog"},
+        |          "doc": "The dogs in the pack"
+        |        }
+        |   ]
+        |}
+        """.trimMargin()
+
+        private val packSchemaByValueStr = """
+        |{
+        |  "type" : "record",
+        |  "name" : "Pack",
+        |  "namespace" : "com.shoprunner.data.dogs",
+        |  "doc" : "It's a Pack of Dogs. Grr Grr!",
+        |  "fields" : [ {
+        |    "name" : "name",
+        |    "type" : "string",
+        |    "doc" : "The name of the pack",
+        |    "aliases" : [ "packName" ]
+        |  }, {
+        |    "name" : "dogs",
+        |    "type" : {
+        |      "type" : "array",
+        |      "items" : {
+        |        "type" : "record",
+        |        "name" : "Dog",
+        |        "doc" : "It's a dog. Ruff Ruff!",
+        |        "fields" : [ {
+        |          "name" : "name",
+        |          "type" : "string",
+        |          "doc" : "The name of the dog"
+        |        }, {
+        |          "name" : "legs",
+        |          "type" : [ "null", "long", "int" ],
+        |          "doc" : "The number of legs",
+        |          "default" : null
+        |        } ]
+        |      }
+        |    },
+        |    "doc" : "The dogs in the pack"
+        |  } ]
+        |}
+        """.trimMargin()
+
+        @Test
+        fun `single model`() {
+            val outputStream = ByteArrayOutputStream()
+            dogDescription.encodeTo(PrintStream(outputStream))
+
+            assertThat(outputStream.toString()).isEqualToIgnoringWhitespace(dogSchemaStr)
+        }
+
+        @Test
+        fun `nested model`() {
+            val outputStream = ByteArrayOutputStream()
+            packDescription.encodeTo(PrintStream(outputStream))
+
+            assertThat(outputStream.toString()).isEqualToIgnoringCase(packSchemaByValueStr)
+        }
+
+        @Test
+        fun `nested model by reference is not supported`() {
+            val outputStream = ByteArrayOutputStream()
+            packDescription.encodeTo(PrintStream(outputStream))
+
+            assertThat(outputStream.toString()).isNotEqualToIgnoringWhitespace(packSchemaByReferenceStr)
+        }
+
+        @Test
+        fun `write to avsc file`() {
+            val dir = File("build/avro-gen-test")
+            val sourceDir = File(dir, "src/main/avro-file")
+            dogDescription.encodeTo(sourceDir)
+
+            val dogFile = File(sourceDir, "com/shoprunner/data/dogs/Dog.avsc")
+            Assertions.assertThat(dogFile).exists()
+        }
+
+        @Test
+        fun `write to avsc path`() {
+            val dir = File("build/avro-gen-test")
+            val sourceDir = File(dir, "src/main/avro-path")
+            dogDescription.encodeTo(sourceDir.toPath())
+
+            val dogFile = File(sourceDir, "com/shoprunner/data/dogs/Dog.avsc")
+            Assertions.assertThat(dogFile).exists()
+        }
     }
 }

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroEncoderTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroEncoderTest.kt
@@ -86,9 +86,9 @@ class AvroEncoderTest {
 
         @Test
         fun `getAvroSchema encodes enum type`() {
-            val schema = AvroEncoder.getAvroSchema(EnumType("a", "b", "c"))
+            val schema = AvroEncoder.getAvroSchema(EnumType("MyEmail", "a", "b", "c"))
             assertThat(schema.type).isEqualTo(Schema.Type.ENUM)
-            assertThat(schema.name).startsWith("GeneratedEnum")
+            assertThat(schema.name).isEqualTo("MyEmail")
             assertThat(schema.enumSymbols).containsExactly("a", "b", "c")
         }
 

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroGeneratorTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroGeneratorTest.kt
@@ -4,7 +4,8 @@ import com.shoprunner.baleen.Baleen
 import com.shoprunner.baleen.BaleenType
 import com.shoprunner.baleen.DataTrace
 import com.shoprunner.baleen.ValidationResult
-import com.shoprunner.baleen.avro.AvroEncoder.encodeTo
+import com.shoprunner.baleen.avro.AvroGenerator.encode
+import com.shoprunner.baleen.avro.AvroGenerator.writeTo
 import com.shoprunner.baleen.types.UnionType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.IntType
@@ -32,61 +33,61 @@ import java.io.File
 import java.io.PrintStream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class AvroEncoderTest {
+class AvroGeneratorTest {
 
     @Nested
     inner class Types {
         @Test
         fun `getAvroSchema encodes the resulting coerced type`() {
-            val schema = AvroEncoder.getAvroSchema(StringCoercibleToFloat(FloatType()))
+            val schema = AvroGenerator.getAvroSchema(StringCoercibleToFloat(FloatType()))
             assertThat(schema.type).isEqualTo(Schema.Type.FLOAT)
         }
 
         @Test
         fun `getAvroSchema encodes boolean type`() {
-            val schema = AvroEncoder.getAvroSchema(BooleanType())
+            val schema = AvroGenerator.getAvroSchema(BooleanType())
             assertThat(schema.type).isEqualTo(Schema.Type.BOOLEAN)
         }
 
         @Test
         fun `getAvroSchema encodes float type`() {
-            val schema = AvroEncoder.getAvroSchema(FloatType())
+            val schema = AvroGenerator.getAvroSchema(FloatType())
             assertThat(schema.type).isEqualTo(Schema.Type.FLOAT)
         }
 
         @Test
         fun `getAvroSchema encodes double type`() {
-            val schema = AvroEncoder.getAvroSchema(DoubleType())
+            val schema = AvroGenerator.getAvroSchema(DoubleType())
             assertThat(schema.type).isEqualTo(Schema.Type.DOUBLE)
         }
 
         @Test
         fun `getAvroSchema encodes int type`() {
-            val schema = AvroEncoder.getAvroSchema(IntType())
+            val schema = AvroGenerator.getAvroSchema(IntType())
             assertThat(schema.type).isEqualTo(Schema.Type.INT)
         }
 
         @Test
         fun `getAvroSchema encodes long type`() {
-            val schema = AvroEncoder.getAvroSchema(LongType())
+            val schema = AvroGenerator.getAvroSchema(LongType())
             assertThat(schema.type).isEqualTo(Schema.Type.LONG)
         }
 
         @Test
         fun `getAvroSchema encodes string type`() {
-            val schema = AvroEncoder.getAvroSchema(StringType())
+            val schema = AvroGenerator.getAvroSchema(StringType())
             assertThat(schema.type).isEqualTo(Schema.Type.STRING)
         }
 
         @Test
         fun `getAvroSchema encodes string constant type`() {
-            val schema = AvroEncoder.getAvroSchema(StringConstantType("abc"))
+            val schema = AvroGenerator.getAvroSchema(StringConstantType("abc"))
             assertThat(schema.type).isEqualTo(Schema.Type.STRING)
         }
 
         @Test
         fun `getAvroSchema encodes enum type`() {
-            val schema = AvroEncoder.getAvroSchema(EnumType("MyEmail", "a", "b", "c"))
+            val schema = AvroGenerator.getAvroSchema(EnumType("MyEmail", "a", "b", "c"))
             assertThat(schema.type).isEqualTo(Schema.Type.ENUM)
             assertThat(schema.name).isEqualTo("MyEmail")
             assertThat(schema.enumSymbols).containsExactly("a", "b", "c")
@@ -94,21 +95,21 @@ class AvroEncoderTest {
 
         @Test
         fun `getAvroSchema encodes instant type`() {
-            val schema = AvroEncoder.getAvroSchema(InstantType())
+            val schema = AvroGenerator.getAvroSchema(InstantType())
             assertThat(schema.type).isEqualTo(Schema.Type.LONG)
             assertThat(schema.logicalType).isEqualTo(LogicalTypes.timestampMillis())
         }
 
         @Test
         fun `getAvroSchema encodes timestamp-millis type`() {
-            val schema = AvroEncoder.getAvroSchema(TimestampMillisType())
+            val schema = AvroGenerator.getAvroSchema(TimestampMillisType())
             assertThat(schema.type).isEqualTo(Schema.Type.LONG)
             assertThat(schema.logicalType).isEqualTo(LogicalTypes.timestampMillis())
         }
 
         @Test
         fun `getAvroSchema encodes map type`() {
-            val schema = AvroEncoder.getAvroSchema(MapType(StringType(), IntType()))
+            val schema = AvroGenerator.getAvroSchema(MapType(StringType(), IntType()))
             assertThat(schema.type).isEqualTo(Schema.Type.MAP)
             assertThat(schema.valueType.type).isEqualTo(Schema.Type.INT)
         }
@@ -116,20 +117,20 @@ class AvroEncoderTest {
         @Test
         fun `getAvroSchema fails map type with non-string key`() {
             assertThrows(Exception::class.java) {
-                AvroEncoder.getAvroSchema(MapType(IntType(), IntType()))
+                AvroGenerator.getAvroSchema(MapType(IntType(), IntType()))
             }
         }
 
         @Test
         fun `getAvroSchema encodes occurences type`() {
-            val schema = AvroEncoder.getAvroSchema(OccurrencesType(StringType()))
+            val schema = AvroGenerator.getAvroSchema(OccurrencesType(StringType()))
             assertThat(schema.type).isEqualTo(Schema.Type.ARRAY)
             assertThat(schema.elementType.type).isEqualTo(Schema.Type.STRING)
         }
 
         @Test
         fun `getAvroSchema encodes non-nullable union type`() {
-            val schema = AvroEncoder.getAvroSchema(UnionType(IntType(), LongType()))
+            val schema = AvroGenerator.getAvroSchema(UnionType(IntType(), LongType()))
             assertThat(schema.type).isEqualTo(Schema.Type.UNION)
             assertThat(schema.types[0].type).isEqualTo(Schema.Type.INT)
             assertThat(schema.types[1].type).isEqualTo(Schema.Type.LONG)
@@ -137,7 +138,7 @@ class AvroEncoderTest {
 
         @Test
         fun `getAvroSchema encodes union type of one not as a union`() {
-            val schema = AvroEncoder.getAvroSchema(UnionType(IntType()))
+            val schema = AvroGenerator.getAvroSchema(UnionType(IntType()))
             assertThat(schema.type).isEqualTo(Schema.Type.INT)
         }
 
@@ -149,7 +150,7 @@ class AvroEncoderTest {
             }
 
             assertThrows(Exception::class.java) {
-                AvroEncoder.getAvroSchema(BadType())
+                AvroGenerator.getAvroSchema(BadType())
             }
         }
     }
@@ -256,7 +257,7 @@ class AvroEncoderTest {
         @Test
         fun `single model`() {
             val outputStream = ByteArrayOutputStream()
-            dogDescription.encodeTo(PrintStream(outputStream))
+            encode(dogDescription).writeTo(PrintStream(outputStream))
 
             assertThat(outputStream.toString()).isEqualToIgnoringWhitespace(dogSchemaStr)
         }
@@ -264,7 +265,7 @@ class AvroEncoderTest {
         @Test
         fun `nested model`() {
             val outputStream = ByteArrayOutputStream()
-            packDescription.encodeTo(PrintStream(outputStream))
+            encode(packDescription).writeTo(PrintStream(outputStream))
 
             assertThat(outputStream.toString()).isEqualToIgnoringCase(packSchemaByValueStr)
         }
@@ -272,7 +273,7 @@ class AvroEncoderTest {
         @Test
         fun `nested model by reference is not supported`() {
             val outputStream = ByteArrayOutputStream()
-            packDescription.encodeTo(PrintStream(outputStream))
+            encode(packDescription).writeTo(PrintStream(outputStream))
 
             assertThat(outputStream.toString()).isNotEqualToIgnoringWhitespace(packSchemaByReferenceStr)
         }
@@ -281,7 +282,7 @@ class AvroEncoderTest {
         fun `write to avsc file`() {
             val dir = File("build/avro-gen-test")
             val sourceDir = File(dir, "src/main/avro-file")
-            dogDescription.encodeTo(sourceDir)
+            encode(dogDescription).writeTo(sourceDir)
 
             val dogFile = File(sourceDir, "com/shoprunner/data/dogs/Dog.avsc")
             Assertions.assertThat(dogFile).exists()
@@ -291,7 +292,7 @@ class AvroEncoderTest {
         fun `write to avsc path`() {
             val dir = File("build/avro-gen-test")
             val sourceDir = File(dir, "src/main/avro-path")
-            dogDescription.encodeTo(sourceDir.toPath())
+            encode(dogDescription).writeTo(sourceDir.toPath())
 
             val dogFile = File(sourceDir, "com/shoprunner/data/dogs/Dog.avsc")
             Assertions.assertThat(dogFile).exists()

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/BaleenEncoderTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/BaleenEncoderTest.kt
@@ -1,0 +1,292 @@
+package com.shoprunner.baleen.avro
+
+import com.shoprunner.baleen.avro.BaleenEncoder.encodeTo
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataDescription
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.PropertySpec
+import org.apache.avro.LogicalType
+import org.apache.avro.Schema
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.File
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.config.Services
+import java.net.URLClassLoader
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class BaleenEncoderTest {
+
+    fun codeToString(codeBlock: CodeBlock): String {
+        val strBuilder = StringBuilder()
+        FileSpec.builder("", "Test")
+                .addProperty(PropertySpec.builder("test", BaleenType::class)
+                        .initializer(codeBlock)
+                        .build())
+                .build()
+                .writeTo(strBuilder)
+        return strBuilder.toString()
+    }
+
+    @Nested
+    inner class AvroField2Baleen {
+
+        @Test
+        fun `processField converts field`() {
+            val f = Schema.Field("name", Schema.create(Schema.Type.INT), "description", 0)
+            val code = BaleenEncoder.processField(f)
+            Assertions.assertThat(codeToString(code)).contains("p.attr(")
+            Assertions.assertThat(codeToString(code)).contains("name = \"name\"")
+            Assertions.assertThat(codeToString(code)).contains("type = IntType()")
+            Assertions.assertThat(codeToString(code)).contains("markdownDescription = \"description\"")
+            Assertions.assertThat(codeToString(code)).contains("required = true")
+        }
+
+        @Test
+        fun `processField converts field with aliases`() {
+            val f = Schema.Field("name", Schema.create(Schema.Type.INT), "description", 0)
+            f.addAlias("aliasName")
+            val code = BaleenEncoder.processField(f)
+            Assertions.assertThat(codeToString(code)).contains("p.attr(")
+            Assertions.assertThat(codeToString(code)).contains("name = \"name\"")
+            Assertions.assertThat(codeToString(code)).contains("type = IntType()")
+            Assertions.assertThat(codeToString(code)).contains("markdownDescription = \"description\"")
+            Assertions.assertThat(codeToString(code)).contains("aliases = arrayOf(\"aliasName\")")
+            Assertions.assertThat(codeToString(code)).contains("required = true")
+        }
+
+        @Test
+        fun `processField converts not required field`() {
+            val fSchema = Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT))
+            val f = Schema.Field("name", fSchema, "description", 0)
+            val code = BaleenEncoder.processField(f)
+            Assertions.assertThat(codeToString(code)).contains("p.attr(")
+            Assertions.assertThat(codeToString(code)).contains("name = \"name\"")
+            Assertions.assertThat(codeToString(code)).contains("type = IntType()")
+            Assertions.assertThat(codeToString(code)).contains("markdownDescription = \"description\"")
+            Assertions.assertThat(codeToString(code)).contains("required = false")
+        }
+
+        @Test
+        fun `processField converts union fields`() {
+            val fSchema = Schema.createUnion(Schema.create(Schema.Type.INT), Schema.create(Schema.Type.LONG))
+            val f = Schema.Field("name", fSchema, "description", 0)
+            val code = BaleenEncoder.processField(f)
+            Assertions.assertThat(codeToString(code)).contains("p.attr(")
+            Assertions.assertThat(codeToString(code)).contains("name = \"name\"")
+            Assertions.assertThat(codeToString(code)).contains("type = UnionType(IntType(), LongType())")
+            Assertions.assertThat(codeToString(code)).contains("markdownDescription = \"description\"")
+            Assertions.assertThat(codeToString(code)).contains("required = true")
+        }
+    }
+
+    @Nested
+    inner class AvroType2Baleen {
+
+        @Test
+        fun `avroTypeToBaleenType converts Boolean`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.BOOLEAN))
+            Assertions.assertThat(codeToString(code)).contains("BooleanType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Double`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.DOUBLE))
+            Assertions.assertThat(codeToString(code)).contains("DoubleType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Float`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.FLOAT))
+            Assertions.assertThat(codeToString(code)).contains("FloatType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Int`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.INT))
+            Assertions.assertThat(codeToString(code)).contains("IntType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Long`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.LONG))
+            Assertions.assertThat(codeToString(code)).contains("LongType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts String`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.STRING))
+            Assertions.assertThat(codeToString(code)).contains("StringType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Enum`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createEnum("myEnum", "", "", listOf("a", "b", "c")))
+            Assertions.assertThat(codeToString(code)).contains("EnumType(\"a\", \"b\", \"c\")")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Array`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createArray(Schema.create(Schema.Type.STRING)))
+            Assertions.assertThat(codeToString(code)).contains("OccurrencesType(StringType())")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Map`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createMap(Schema.create(Schema.Type.INT)))
+            Assertions.assertThat(codeToString(code)).contains("MapType(StringType(), IntType())")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Record`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createRecord("MyRecord", "", "com.shoprunner.data", false))
+            Assertions.assertThat(codeToString(code)).contains("com.shoprunner.data.MyRecordType.description")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Union`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createUnion(Schema.create(Schema.Type.INT), Schema.create(Schema.Type.LONG)))
+            Assertions.assertThat(codeToString(code)).contains("UnionType(IntType(), LongType())")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Nullable Type Union`() {
+            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)))
+            Assertions.assertThat(codeToString(code)).contains("LongType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Int date`() {
+            val timestampMilliSchema = LogicalType("date").addToSchema(Schema.create(Schema.Type.INT))
+            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            Assertions.assertThat(codeToString(code)).contains("IntType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Int time-millis`() {
+            val timestampMilliSchema = LogicalType("time-millis").addToSchema(Schema.create(Schema.Type.INT))
+            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            Assertions.assertThat(codeToString(code)).contains("IntType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Long time-micros`() {
+            val timestampMilliSchema = LogicalType("timestamp-millis").addToSchema(Schema.create(Schema.Type.LONG))
+            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            Assertions.assertThat(codeToString(code)).contains("LongCoercibleToInstant()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Long timestamp-millis`() {
+            val timestampMilliSchema = LogicalType("time-micros").addToSchema(Schema.create(Schema.Type.LONG))
+            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            Assertions.assertThat(codeToString(code)).contains("LongType()")
+        }
+
+        @Test
+        fun `avroTypeToBaleenType converts Long timestamp-micros`() {
+            val timestampMilliSchema = LogicalType("timestamp-micros").addToSchema(Schema.create(Schema.Type.LONG))
+            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            Assertions.assertThat(codeToString(code)).contains("LongType()")
+        }
+    }
+
+    @Nested
+    inner class CheckFileGeneration {
+        val parser = Schema.Parser()
+        val dogSchemaStr = """
+        |{
+        |   "type": "record",
+        |   "namespace": "com.shoprunner.data.dogs",
+        |   "name": "Dog",
+        |   "doc": "It's a dog. Ruff Ruff!",
+        |   "fields": [
+        |        { "name": "name", "type": "string", "doc": "The name of the dog" },
+        |        { "name": "legs", "type": ["long", "int", "null"], "default": null, "doc": "The number of legs" }
+        |   ]
+        |}
+        """.trimMargin()
+        val dogSchema = parser.parse(dogSchemaStr)
+
+        val packSchemaStr = """
+        |{
+        |   "type": "record",
+        |   "namespace": "com.shoprunner.data.dogs",
+        |   "name": "Pack",
+        |   "doc": "It's a Pack of Dogs. Grr Grr!",
+        |   "fields": [
+        |        { "name": "name", "type": "string", "doc": "The name of the pack", "aliases": [ "packName" ] },
+        |        {
+        |          "name": "dogs",
+        |          "type": {"type": "array", "items": "com.shoprunner.data.dogs.Dog"},
+        |          "doc": "The dogs in the pack"
+        |        }
+        |   ]
+        |}
+        """.trimMargin()
+        val packSchema = parser.parse(packSchemaStr)
+
+        inner class LogMessageCollector : MessageCollector {
+            override fun clear() = Unit
+
+            override fun hasErrors() = false
+
+            override fun report(severity: CompilerMessageSeverity, message: String, location: CompilerMessageLocation?) {
+                println("$severity: $message : $location")
+            }
+        }
+
+        @Test
+        fun `generate code from Avro Schema that compiles`() {
+            // Setup
+            val dir = File("build/avro-gen-test")
+            val sourceDir = File(dir, "src/main/kotlin")
+            sourceDir.mkdirs()
+            val classesDir = File(dir, "classes/main/kotlin")
+            classesDir.mkdirs()
+
+            // Generate Baleen Kotlin Files
+            dogSchema.encodeTo(sourceDir)
+            val dogFile = File(sourceDir, "com/shoprunner/data/dogs/DogType.kt")
+            Assertions.assertThat(dogFile).exists()
+
+            packSchema.encodeTo(sourceDir)
+            val packFile = File(sourceDir, "com/shoprunner/data/dogs/PackType.kt")
+            Assertions.assertThat(packFile).exists()
+
+            // Needs the Environment Variable passed in in order to compile. Gradle can give us this.
+            Assertions.assertThat(System.getenv("GEN_CLASSPATH")).isNotBlank()
+
+            val compiler = K2JVMCompiler()
+            val args = K2JVMCompilerArguments().apply {
+                destination = classesDir.path
+                freeArgs = listOf(sourceDir.path)
+                classpath = System.getenv("GEN_CLASSPATH")
+                noStdlib = true
+            }
+            compiler.exec(LogMessageCollector(), Services.EMPTY, args)
+
+            // Check that compilation worked
+            Assertions.assertThat(File(classesDir, "com/shoprunner/data/dogs/DogType.class")).exists()
+            Assertions.assertThat(File(classesDir, "com/shoprunner/data/dogs/PackType.class")).exists()
+
+            // Check if the compiled files can be loaded
+            val cl = URLClassLoader(arrayOf(classesDir.toURI().toURL()))
+
+            val dogType = cl.loadClass("com.shoprunner.data.dogs.DogType")
+            val dogDescription = dogType.getDeclaredField("description").type
+            Assertions.assertThat(dogDescription).isEqualTo(DataDescription::class.java)
+
+            val packType = cl.loadClass("com.shoprunner.data.dogs.PackType")
+            val packDescription = packType.getDeclaredField("description").type
+            Assertions.assertThat(packDescription).isEqualTo(DataDescription::class.java)
+        }
+    }
+}

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/BaleenEncoderTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/BaleenEncoderTest.kt
@@ -180,7 +180,7 @@ internal class BaleenEncoderTest {
         fun `avroTypeToBaleenType converts Long time-micros`() {
             val timestampMilliSchema = LogicalType("timestamp-millis").addToSchema(Schema.create(Schema.Type.LONG))
             val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
-            Assertions.assertThat(codeToString(code)).contains("LongCoercibleToInstant()")
+            Assertions.assertThat(codeToString(code)).contains("LongCoercibleToInstant(InstantType())")
         }
 
         @Test

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/BaleenGeneratorTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/BaleenGeneratorTest.kt
@@ -1,6 +1,6 @@
 package com.shoprunner.baleen.avro
 
-import com.shoprunner.baleen.avro.BaleenEncoder.encodeTo
+import com.shoprunner.baleen.avro.BaleenGenerator.encode
 import com.shoprunner.baleen.BaleenType
 import com.shoprunner.baleen.DataDescription
 import com.squareup.kotlinpoet.CodeBlock
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.config.Services
 import java.net.URLClassLoader
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class BaleenEncoderTest {
+internal class BaleenGeneratorTest {
 
     fun codeToString(codeBlock: CodeBlock): String {
         val strBuilder = StringBuilder()
@@ -41,7 +41,7 @@ internal class BaleenEncoderTest {
         @Test
         fun `processField converts field`() {
             val f = Schema.Field("name", Schema.create(Schema.Type.INT), "description", 0)
-            val code = BaleenEncoder.processField(f)
+            val code = BaleenGenerator.processField(f)
             Assertions.assertThat(codeToString(code)).contains("p.attr(")
             Assertions.assertThat(codeToString(code)).contains("name = \"name\"")
             Assertions.assertThat(codeToString(code)).contains("type = IntType()")
@@ -53,7 +53,7 @@ internal class BaleenEncoderTest {
         fun `processField converts field with aliases`() {
             val f = Schema.Field("name", Schema.create(Schema.Type.INT), "description", 0)
             f.addAlias("aliasName")
-            val code = BaleenEncoder.processField(f)
+            val code = BaleenGenerator.processField(f)
             Assertions.assertThat(codeToString(code)).contains("p.attr(")
             Assertions.assertThat(codeToString(code)).contains("name = \"name\"")
             Assertions.assertThat(codeToString(code)).contains("type = IntType()")
@@ -66,7 +66,7 @@ internal class BaleenEncoderTest {
         fun `processField converts not required field`() {
             val fSchema = Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT))
             val f = Schema.Field("name", fSchema, "description", 0)
-            val code = BaleenEncoder.processField(f)
+            val code = BaleenGenerator.processField(f)
             Assertions.assertThat(codeToString(code)).contains("p.attr(")
             Assertions.assertThat(codeToString(code)).contains("name = \"name\"")
             Assertions.assertThat(codeToString(code)).contains("type = IntType()")
@@ -78,7 +78,7 @@ internal class BaleenEncoderTest {
         fun `processField converts union fields`() {
             val fSchema = Schema.createUnion(Schema.create(Schema.Type.INT), Schema.create(Schema.Type.LONG))
             val f = Schema.Field("name", fSchema, "description", 0)
-            val code = BaleenEncoder.processField(f)
+            val code = BaleenGenerator.processField(f)
             Assertions.assertThat(codeToString(code)).contains("p.attr(")
             Assertions.assertThat(codeToString(code)).contains("name = \"name\"")
             Assertions.assertThat(codeToString(code)).contains("type = UnionType(IntType(), LongType())")
@@ -92,108 +92,108 @@ internal class BaleenEncoderTest {
 
         @Test
         fun `avroTypeToBaleenType converts Boolean`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.BOOLEAN))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.create(Schema.Type.BOOLEAN))
             Assertions.assertThat(codeToString(code)).contains("BooleanType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Double`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.DOUBLE))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.create(Schema.Type.DOUBLE))
             Assertions.assertThat(codeToString(code)).contains("DoubleType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Float`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.FLOAT))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.create(Schema.Type.FLOAT))
             Assertions.assertThat(codeToString(code)).contains("FloatType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Int`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.INT))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.create(Schema.Type.INT))
             Assertions.assertThat(codeToString(code)).contains("IntType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Long`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.LONG))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.create(Schema.Type.LONG))
             Assertions.assertThat(codeToString(code)).contains("LongType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts String`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.create(Schema.Type.STRING))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.create(Schema.Type.STRING))
             Assertions.assertThat(codeToString(code)).contains("StringType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Enum`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createEnum("myEnum", "", "", listOf("a", "b", "c")))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.createEnum("myEnum", "", "", listOf("a", "b", "c")))
             Assertions.assertThat(codeToString(code)).contains("EnumType(\"a\", \"b\", \"c\")")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Array`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createArray(Schema.create(Schema.Type.STRING)))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.createArray(Schema.create(Schema.Type.STRING)))
             Assertions.assertThat(codeToString(code)).contains("OccurrencesType(StringType())")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Map`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createMap(Schema.create(Schema.Type.INT)))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.createMap(Schema.create(Schema.Type.INT)))
             Assertions.assertThat(codeToString(code)).contains("MapType(StringType(), IntType())")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Record`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createRecord("MyRecord", "", "com.shoprunner.data", false))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.createRecord("MyRecord", "", "com.shoprunner.data", false))
             Assertions.assertThat(codeToString(code)).contains("com.shoprunner.data.MyRecordType.description")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Union`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createUnion(Schema.create(Schema.Type.INT), Schema.create(Schema.Type.LONG)))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.createUnion(Schema.create(Schema.Type.INT), Schema.create(Schema.Type.LONG)))
             Assertions.assertThat(codeToString(code)).contains("UnionType(IntType(), LongType())")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Nullable Type Union`() {
-            val code = BaleenEncoder.avroTypeToBaleenType(Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)))
+            val code = BaleenGenerator.avroTypeToBaleenType(Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)))
             Assertions.assertThat(codeToString(code)).contains("LongType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Int date`() {
             val timestampMilliSchema = LogicalType("date").addToSchema(Schema.create(Schema.Type.INT))
-            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            val code = BaleenGenerator.avroTypeToBaleenType(timestampMilliSchema)
             Assertions.assertThat(codeToString(code)).contains("IntType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Int time-millis`() {
             val timestampMilliSchema = LogicalType("time-millis").addToSchema(Schema.create(Schema.Type.INT))
-            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            val code = BaleenGenerator.avroTypeToBaleenType(timestampMilliSchema)
             Assertions.assertThat(codeToString(code)).contains("IntType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Long time-micros`() {
             val timestampMilliSchema = LogicalType("timestamp-millis").addToSchema(Schema.create(Schema.Type.LONG))
-            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            val code = BaleenGenerator.avroTypeToBaleenType(timestampMilliSchema)
             Assertions.assertThat(codeToString(code)).contains("LongCoercibleToInstant(InstantType())")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Long timestamp-millis`() {
             val timestampMilliSchema = LogicalType("time-micros").addToSchema(Schema.create(Schema.Type.LONG))
-            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            val code = BaleenGenerator.avroTypeToBaleenType(timestampMilliSchema)
             Assertions.assertThat(codeToString(code)).contains("LongType()")
         }
 
         @Test
         fun `avroTypeToBaleenType converts Long timestamp-micros`() {
             val timestampMilliSchema = LogicalType("timestamp-micros").addToSchema(Schema.create(Schema.Type.LONG))
-            val code = BaleenEncoder.avroTypeToBaleenType(timestampMilliSchema)
+            val code = BaleenGenerator.avroTypeToBaleenType(timestampMilliSchema)
             Assertions.assertThat(codeToString(code)).contains("LongType()")
         }
     }
@@ -253,11 +253,11 @@ internal class BaleenEncoderTest {
             classesDir.mkdirs()
 
             // Generate Baleen Kotlin Files
-            dogSchema.encodeTo(sourceDir)
+            encode(dogSchema).writeTo(sourceDir)
             val dogFile = File(sourceDir, "com/shoprunner/data/dogs/DogType.kt")
             Assertions.assertThat(dogFile).exists()
 
-            packSchema.encodeTo(sourceDir)
+            encode(packSchema).writeTo(sourceDir)
             val packFile = File(sourceDir, "com/shoprunner/data/dogs/PackType.kt")
             Assertions.assertThat(packFile).exists()
 

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/BooleanType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/BooleanType.kt
@@ -1,0 +1,17 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationResult
+
+class BooleanType() : BaleenType {
+    override fun name() = "boolean"
+
+    override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
+            when {
+                value == null -> sequenceOf(ValidationError(dataTrace, "is null", value))
+                value !is Boolean -> sequenceOf(ValidationError(dataTrace, "is not a boolean", value))
+                else -> emptySequence()
+            }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/CoercibleType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/CoercibleType.kt
@@ -1,0 +1,5 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+
+abstract class CoercibleType(val type: BaleenType) : BaleenType

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/DoubleType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/DoubleType.kt
@@ -1,0 +1,19 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationResult
+
+class DoubleType(val min: Double = Double.NEGATIVE_INFINITY, val max: Double = Double.POSITIVE_INFINITY) : BaleenType {
+    override fun name() = "double"
+
+    override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
+            when {
+                value == null -> sequenceOf(ValidationError(dataTrace, "is null", value))
+                value !is Double -> sequenceOf(ValidationError(dataTrace, "is not a double", value))
+                value < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                value > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                else -> emptySequence()
+            }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/EnumType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/EnumType.kt
@@ -1,0 +1,24 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationResult
+
+class EnumType(vararg val enum: String) : BaleenType {
+    override fun name() = "enum"
+
+    override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
+            when {
+                value == null -> sequenceOf(ValidationError(dataTrace, "is null", value))
+                value is String && !enum.contains(value) ->
+                    sequenceOf(ValidationError(dataTrace,
+                            "is not contained in enum [${enum.joinToString(",")}]",
+                            value))
+                value is Enum<*> && !enum.contains(value.name) ->
+                    sequenceOf(ValidationError(dataTrace,
+                            "is not contained in enum [${enum.joinToString(",")}]",
+                            value))
+                else -> emptySequence()
+            }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/EnumType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/EnumType.kt
@@ -5,7 +5,13 @@ import com.shoprunner.baleen.DataTrace
 import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.ValidationResult
 
-class EnumType(vararg val enum: String) : BaleenType {
+class EnumType(val enum: List<String>) : BaleenType {
+
+    constructor(vararg enum: String) : this(enum.toList())
+
+    constructor(enum: Array<out Enum<*>>) : this(enum.map { it.name })
+
+
     override fun name() = "enum"
 
     override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
@@ -13,11 +19,11 @@ class EnumType(vararg val enum: String) : BaleenType {
                 value == null -> sequenceOf(ValidationError(dataTrace, "is null", value))
                 value is String && !enum.contains(value) ->
                     sequenceOf(ValidationError(dataTrace,
-                            "is not contained in enum [${enum.joinToString(",")}]",
+                            "is not contained in enum [${enum.joinToString(", ")}]",
                             value))
                 value is Enum<*> && !enum.contains(value.name) ->
                     sequenceOf(ValidationError(dataTrace,
-                            "is not contained in enum [${enum.joinToString(",")}]",
+                            "is not contained in enum [${enum.joinToString(", ")}]",
                             value))
                 else -> emptySequence()
             }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/EnumType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/EnumType.kt
@@ -11,7 +11,6 @@ class EnumType(val enum: List<String>) : BaleenType {
 
     constructor(enum: Array<out Enum<*>>) : this(enum.map { it.name })
 
-
     override fun name() = "enum"
 
     override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/EnumType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/EnumType.kt
@@ -5,11 +5,13 @@ import com.shoprunner.baleen.DataTrace
 import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.ValidationResult
 
-class EnumType(val enum: List<String>) : BaleenType {
+class EnumType(val enumName: String, val enum: List<String>) : BaleenType {
 
-    constructor(vararg enum: String) : this(enum.toList())
+    constructor(enumName: String, vararg enum: String) : this(enumName, enum.toList())
 
-    constructor(enum: Array<out Enum<*>>) : this(enum.map { it.name })
+    constructor(enumName: String, enum: Array<out Enum<*>>) : this(enumName, enum.map { it.name })
+
+    private val enumStr = enum.joinToString(", ")
 
     override fun name() = "enum"
 
@@ -18,11 +20,11 @@ class EnumType(val enum: List<String>) : BaleenType {
                 value == null -> sequenceOf(ValidationError(dataTrace, "is null", value))
                 value is String && !enum.contains(value) ->
                     sequenceOf(ValidationError(dataTrace,
-                            "is not contained in enum [${enum.joinToString(", ")}]",
+                            "is not contained in enum $enumName [$enumStr]",
                             value))
                 value is Enum<*> && !enum.contains(value.name) ->
                     sequenceOf(ValidationError(dataTrace,
-                            "is not contained in enum [${enum.joinToString(", ")}]",
+                            "is not contained in enum $enumName [$enumStr]",
                             value))
                 else -> emptySequence()
             }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/InstantType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/InstantType.kt
@@ -1,0 +1,18 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationResult
+import java.time.Instant
+
+class InstantType : BaleenType {
+    override fun name() = "instant"
+
+    override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
+            when (value) {
+                null -> sequenceOf(ValidationError(dataTrace, "is null", value))
+                !is Instant -> sequenceOf(ValidationError(dataTrace, "is not a instant", value))
+                else -> emptySequence()
+            }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/InstantType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/InstantType.kt
@@ -6,13 +6,15 @@ import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.ValidationResult
 import java.time.Instant
 
-class InstantType : BaleenType {
+class InstantType(val before: Instant = Instant.MAX, val after: Instant = Instant.MIN) : BaleenType {
     override fun name() = "instant"
 
     override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
             when (value) {
                 null -> sequenceOf(ValidationError(dataTrace, "is null", value))
-                !is Instant -> sequenceOf(ValidationError(dataTrace, "is not a instant", value))
+                !is Instant -> sequenceOf(ValidationError(dataTrace, "is not an instant", value))
+                !value.isBefore(before) -> sequenceOf(ValidationError(dataTrace, "is before $before", value))
+                !value.isAfter(after) -> sequenceOf(ValidationError(dataTrace, "is after $after", value))
                 else -> emptySequence()
             }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/IntType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/IntType.kt
@@ -1,0 +1,19 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationResult
+
+class IntType(val min: Int = Int.MIN_VALUE, val max: Int = Int.MAX_VALUE) : BaleenType {
+    override fun name() = "int"
+
+    override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
+            when {
+                value == null -> sequenceOf(ValidationError(dataTrace, "is null", value))
+                value !is Int -> sequenceOf(ValidationError(dataTrace, "is not an Int", value))
+                value < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                value > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                else -> sequenceOf()
+            }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/LongCoercibleToInstant.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/LongCoercibleToInstant.kt
@@ -1,0 +1,16 @@
+package com.shoprunner.baleen.types
+
+import java.time.Instant
+
+class LongCoercibleToInstant(instantType: InstantType, precision: Precision = Precision.millis) :
+        LongCoercibleToType<InstantType>(instantType, {
+            when (precision) {
+                Precision.millis -> Instant.ofEpochMilli(it)
+            }
+        }) {
+
+    enum class Precision {
+        millis
+        // TODO: Add nanos, since Avro supports nano resolution
+    }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/LongCoercibleToType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/LongCoercibleToType.kt
@@ -5,13 +5,13 @@ import com.shoprunner.baleen.DataTrace
 import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.ValidationResult
 
-open class StringCoercibleToType<out T : BaleenType>(type: T, private val converter: (String) -> Any?) : CoercibleType(type) {
-    override fun name() = "string coercible to ${type.name()}"
+open class LongCoercibleToType<out T : BaleenType>(type: T, private val converter: (Long) -> Any?) : CoercibleType(type) {
+    override fun name() = "long coercible to ${type.name()}"
 
     override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
             when (value) {
                 null -> type.validate(dataTrace, value)
-                !is String -> sequenceOf(ValidationError(dataTrace, "is not a string", value))
+                !is Long -> sequenceOf(ValidationError(dataTrace, "is not a long", value))
                 else -> {
                     val newType = converter(value)
                     if (newType == null) {

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/MapType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/MapType.kt
@@ -1,0 +1,22 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationResult
+
+class MapType(val keyType: BaleenType, val valueType: BaleenType) : BaleenType {
+
+    override fun name() = "map of occurrences of ${keyType.name()} to ${valueType.name()}"
+
+    override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
+            when (value) {
+                null -> sequenceOf(ValidationError(dataTrace, "is null", value))
+                value !is Map<*, *> -> sequenceOf(ValidationError(dataTrace, "is not a map", value))
+                is Map<*, *> -> value.asSequence().withIndex().flatMap { (index, data) ->
+                    keyType.validate(dataTrace.plus("index $index key"), data.key) +
+                    valueType.validate(dataTrace.plus("index $index value"), data.value)
+                }
+                else -> emptySequence()
+            }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/StringCoercibleToInstant.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/StringCoercibleToInstant.kt
@@ -1,0 +1,15 @@
+package com.shoprunner.baleen.types
+
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+class StringCoercibleToInstant(instantType: InstantType,
+                               dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ISO_INSTANT) :
+        StringCoercibleToType<InstantType>(instantType, {
+            try {
+                dateTimeFormatter.parse(it, Instant::from)
+            } catch (ex: DateTimeParseException) {
+                null
+            }
+        })

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/StringCoercibleToInstant.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/StringCoercibleToInstant.kt
@@ -4,8 +4,10 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
-class StringCoercibleToInstant(instantType: InstantType,
-                               dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ISO_INSTANT) :
+class StringCoercibleToInstant(
+    instantType: InstantType,
+    dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ISO_INSTANT
+) :
         StringCoercibleToType<InstantType>(instantType, {
             try {
                 dateTimeFormatter.parse(it, Instant::from)

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/StringCoercibleToType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/StringCoercibleToType.kt
@@ -15,7 +15,7 @@ open class StringCoercibleToType<out T : BaleenType>(type: T, private val conver
                 else -> {
                     val newType = converter(value)
                     if (newType == null) {
-                        sequenceOf(ValidationError(dataTrace, "could not be parsed to ${type.name()}.", value))
+                        sequenceOf(ValidationError(dataTrace, "could not be parsed to ${type.name()}", value))
                     } else {
                         type.validate(dataTrace, newType)
                     }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/AllowsNullTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/AllowsNullTest.kt
@@ -1,0 +1,19 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class AllowsNullTest {
+    @Test
+    fun `passes a non-null`() {
+        assertThat(AllowsNull(LongType()).validate(dataTrace(), 0L)).isEmpty()
+    }
+
+    @Test
+    fun `passes null`() {
+        assertThat(AllowsNull(LongType()).validate(dataTrace(), null)).isEmpty()
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/BooleanTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/BooleanTypeTest.kt
@@ -1,0 +1,26 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class BooleanTypeTest {
+    @Test
+    fun `passes a boolean`() {
+        assertThat(BooleanType().validate(dataTrace(), true)).isEmpty()
+        assertThat(BooleanType().validate(dataTrace(), false)).isEmpty()
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(BooleanType().validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not Boolean`() {
+        assertThat(BooleanType().validate(dataTrace(), 0L)).containsExactly(ValidationError(dataTrace(), "is not a boolean", 0L))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/DoubleTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/DoubleTypeTest.kt
@@ -1,0 +1,39 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class DoubleTypeTest {
+    @Test
+    fun `passes a Double`() {
+        assertThat(DoubleType().validate(dataTrace(), 0.0)).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value`() {
+        assertThat(DoubleType(min = 1.0).validate(dataTrace(), 0.0)).containsExactly(ValidationError(dataTrace(), "is less than 1.0", 0.0))
+        assertThat(DoubleType(min = 1.0).validate(dataTrace(), 1.0)).isEmpty()
+        assertThat(DoubleType(min = 1.0).validate(dataTrace(), 2.0)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value`() {
+        assertThat(DoubleType(max = 1.0).validate(dataTrace(), 0.0)).isEmpty()
+        assertThat(DoubleType(max = 1.0).validate(dataTrace(), 1.0)).isEmpty()
+        assertThat(DoubleType(max = 1.0).validate(dataTrace(), 2.0)).containsExactly(ValidationError(dataTrace(), "is greater than 1.0", 2.0))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(DoubleType().validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not Double`() {
+        assertThat(DoubleType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a double", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/EnumTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/EnumTypeTest.kt
@@ -19,30 +19,30 @@ internal class EnumTypeTest {
 
     @Test
     fun `passes string enum`() {
-        assertThat(EnumType("a", "b", "c").validate(dataTrace(), "a")).isEmpty()
-        assertThat(EnumType("a", "b", "c").validate(dataTrace(), "b")).isEmpty()
-        assertThat(EnumType("a", "b", "c").validate(dataTrace(), "c")).isEmpty()
+        assertThat(EnumType("Alphabet", "a", "b", "c").validate(dataTrace(), "a")).isEmpty()
+        assertThat(EnumType("Alphabet", "a", "b", "c").validate(dataTrace(), "b")).isEmpty()
+        assertThat(EnumType("Alphabet", "a", "b", "c").validate(dataTrace(), "c")).isEmpty()
     }
 
     @Test
     fun `passes enum objects`() {
-        assertThat(EnumType(Alphabet.values()).validate(dataTrace(), Alphabet.a)).isEmpty()
-        assertThat(EnumType(Alphabet.values()).validate(dataTrace(), Alphabet.b)).isEmpty()
-        assertThat(EnumType(Alphabet.values()).validate(dataTrace(), Alphabet.c)).isEmpty()
+        assertThat(EnumType("Alphabet", Alphabet.values()).validate(dataTrace(), Alphabet.a)).isEmpty()
+        assertThat(EnumType("Alphabet", Alphabet.values()).validate(dataTrace(), Alphabet.b)).isEmpty()
+        assertThat(EnumType("Alphabet", Alphabet.values()).validate(dataTrace(), Alphabet.c)).isEmpty()
     }
 
     @Test
     fun `checks unsupported string enums`() {
-        assertThat(EnumType("a", "b", "c").validate(dataTrace(), "one")).containsExactly(ValidationError(dataTrace(), "is not contained in enum [a, b, c]", "one"))
+        assertThat(EnumType("Alphabet", "a", "b", "c").validate(dataTrace(), "one")).containsExactly(ValidationError(dataTrace(), "is not contained in enum Alphabet [a, b, c]", "one"))
     }
 
     @Test
     fun `checks unsupported enums`() {
-        assertThat(EnumType(Alphabet.values()).validate(dataTrace(), Numbers.one)).containsExactly(ValidationError(dataTrace(), "is not contained in enum [a, b, c]", Numbers.one))
+        assertThat(EnumType("Alphabet", Alphabet.values()).validate(dataTrace(), Numbers.one)).containsExactly(ValidationError(dataTrace(), "is not contained in enum Alphabet [a, b, c]", Numbers.one))
     }
 
     @Test
     fun `checks null`() {
-        assertThat(EnumType("a", "b", "c").validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+        assertThat(EnumType("Alphabet", "a", "b", "c").validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
     }
 }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/EnumTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/EnumTypeTest.kt
@@ -1,0 +1,48 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class EnumTypeTest {
+
+    enum class Alphabet {
+        a, b, c
+    }
+
+    enum class Numbers {
+        one, two, three
+    }
+
+    @Test
+    fun `passes string enum`() {
+        assertThat(EnumType("a", "b", "c").validate(dataTrace(), "a")).isEmpty()
+        assertThat(EnumType("a", "b", "c").validate(dataTrace(), "b")).isEmpty()
+        assertThat(EnumType("a", "b", "c").validate(dataTrace(), "c")).isEmpty()
+    }
+
+    @Test
+    fun `passes enum objects`() {
+        assertThat(EnumType(Alphabet.values()).validate(dataTrace(), Alphabet.a)).isEmpty()
+        assertThat(EnumType(Alphabet.values()).validate(dataTrace(), Alphabet.b)).isEmpty()
+        assertThat(EnumType(Alphabet.values()).validate(dataTrace(), Alphabet.c)).isEmpty()
+    }
+
+    @Test
+    fun `checks unsupported string enums`() {
+        assertThat(EnumType("a", "b", "c").validate(dataTrace(), "one")).containsExactly(ValidationError(dataTrace(), "is not contained in enum [a, b, c]", "one"))
+    }
+
+    @Test
+    fun `checks unsupported enums`() {
+        assertThat(EnumType(Alphabet.values()).validate(dataTrace(), Numbers.one)).containsExactly(ValidationError(dataTrace(), "is not contained in enum [a, b, c]", Numbers.one))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(EnumType("a", "b", "c").validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/FloatTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/FloatTypeTest.kt
@@ -1,0 +1,39 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class FloatTypeTest {
+    @Test
+    fun `passes a Float`() {
+        assertThat(FloatType().validate(dataTrace(), 0.0F)).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value`() {
+        assertThat(FloatType(min = 1.0F).validate(dataTrace(), 0.0F)).containsExactly(ValidationError(dataTrace(), "is less than 1.0", 0.0F))
+        assertThat(FloatType(min = 1.0F).validate(dataTrace(), 1.0F)).isEmpty()
+        assertThat(FloatType(min = 1.0F).validate(dataTrace(), 2.0F)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value`() {
+        assertThat(FloatType(max = 1.0F).validate(dataTrace(), 0.0F)).isEmpty()
+        assertThat(FloatType(max = 1.0F).validate(dataTrace(), 1.0F)).isEmpty()
+        assertThat(FloatType(max = 1.0F).validate(dataTrace(), 2.0F)).containsExactly(ValidationError(dataTrace(), "is greater than 1.0", 2.0F))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(FloatType().validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not Float`() {
+        assertThat(FloatType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a float", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/InstantTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/InstantTypeTest.kt
@@ -1,0 +1,46 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class InstantTypeTest {
+    @Test
+    fun `passes an Instant`() {
+        assertThat(InstantType().validate(dataTrace(), Instant.now())).isEmpty()
+    }
+
+    @Test
+    fun `checks value after`() {
+        val day = Instant.parse("2018-07-01T10:15:30Z")
+        val before = Instant.parse("2018-06-30T10:15:30Z")
+        val after = Instant.parse("2018-07-02T10:15:30Z")
+        assertThat(InstantType(after = day).validate(dataTrace(), before)).containsExactly(ValidationError(dataTrace(), "is before 2018-07-01T10:15:30Z", 0L))
+        assertThat(InstantType(after = day).validate(dataTrace(), day)).isEmpty()
+        assertThat(InstantType(after = day).validate(dataTrace(), after)).isEmpty()
+    }
+
+    @Test
+    fun `checks value before`() {
+        val day = Instant.parse("2018-07-01T10:15:30Z")
+        val before = Instant.parse("2018-06-30T10:15:30Z")
+        val after = Instant.parse("2018-07-02T10:15:30Z")
+        assertThat(InstantType(before = day).validate(dataTrace(), before)).isEmpty()
+        assertThat(InstantType(before = day).validate(dataTrace(), day)).isEmpty()
+        assertThat(InstantType(before = day).validate(dataTrace(), after)).containsExactly(ValidationError(dataTrace(), "is after 2018-07-01T10:15:30Z", 2L))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(InstantType().validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not Instant`() {
+        assertThat(InstantType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not an instant", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/IntTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/IntTypeTest.kt
@@ -1,0 +1,39 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class IntTypeTest {
+    @Test
+    fun `passes a Int`() {
+        assertThat(IntType().validate(dataTrace(), 0)).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value`() {
+        assertThat(IntType(min = 1).validate(dataTrace(), 0)).containsExactly(ValidationError(dataTrace(), "is less than 1", 0))
+        assertThat(IntType(min = 1).validate(dataTrace(), 1)).isEmpty()
+        assertThat(IntType(min = 1).validate(dataTrace(), 2)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value`() {
+        assertThat(IntType(max = 1).validate(dataTrace(), 0)).isEmpty()
+        assertThat(IntType(max = 1).validate(dataTrace(), 1)).isEmpty()
+        assertThat(IntType(max = 1).validate(dataTrace(), 2)).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(IntType().validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not Int`() {
+        assertThat(IntType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not an Int", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/LongCoercibleToInstantTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/LongCoercibleToInstantTest.kt
@@ -1,0 +1,26 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class LongCoercibleToInstantTest {
+    @Test
+    fun `passes an instant as long`() {
+        assertThat(LongCoercibleToInstant(InstantType()).validate(dataTrace(), Instant.now().toEpochMilli())).isEmpty()
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(LongCoercibleToInstant(InstantType()).validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not long`() {
+        assertThat(LongCoercibleToInstant(InstantType()).validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a long", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/LongTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/LongTypeTest.kt
@@ -19,4 +19,21 @@ internal class LongTypeTest {
         assertThat(LongType(min = 1).validate(dataTrace(), 1L)).isEmpty()
         assertThat(LongType(min = 1).validate(dataTrace(), 2L)).isEmpty()
     }
+
+    @Test
+    fun `checks maximum value`() {
+        assertThat(LongType(max = 1).validate(dataTrace(), 0L)).isEmpty()
+        assertThat(LongType(max = 1).validate(dataTrace(), 1L)).isEmpty()
+        assertThat(LongType(max = 1).validate(dataTrace(), 2L)).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2L))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(LongType().validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not Long`() {
+        assertThat(LongType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a long", false))
+    }
 }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/MapTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/MapTypeTest.kt
@@ -1,0 +1,35 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class MapTypeTest {
+    @Test
+    fun `passes a map`() {
+        assertThat(MapType(StringType(), IntType()).validate(dataTrace(), mapOf("One" to 1))).isEmpty()
+    }
+
+    @Test
+    fun `checks key type`() {
+        assertThat(MapType(StringType(), IntType()).validate(dataTrace(), mapOf(1 to 1))).containsExactly(ValidationError(dataTrace("index 0 key"), "is not a string", 1))
+    }
+
+    @Test
+    fun `checks value type`() {
+        assertThat(MapType(StringType(), IntType()).validate(dataTrace(), mapOf("One" to "one"))).containsExactly(ValidationError(dataTrace("index 0 value"), "is not an Int", "one"))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(MapType(StringType(), IntType()).validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not Map`() {
+        assertThat(MapType(StringType(), IntType()).validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a map", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToFloatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToFloatTest.kt
@@ -5,7 +5,6 @@ import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.dataTrace
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.time.Instant
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class StringCoercibleToFloatTest {

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToFloatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToFloatTest.kt
@@ -1,0 +1,31 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class StringCoercibleToFloatTest {
+    @Test
+    fun `passes an instant as string`() {
+        assertThat(StringCoercibleToFloat(FloatType()).validate(dataTrace(), "1.0")).isEmpty()
+    }
+
+    @Test
+    fun `checks if an string is not float format`() {
+        assertThat(StringCoercibleToFloat(FloatType()).validate(dataTrace(), "bad string")).containsExactly(ValidationError(dataTrace(), "could not be parsed to float", "bad string"))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(StringCoercibleToFloat(FloatType()).validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not string`() {
+        assertThat(StringCoercibleToFloat(FloatType()).validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a string", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToInstantTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToInstantTest.kt
@@ -1,0 +1,31 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class StringCoercibleToInstantTest {
+    @Test
+    fun `passes an instant as string`() {
+        assertThat(StringCoercibleToInstant(InstantType()).validate(dataTrace(), "2018-07-01T10:15:30Z")).isEmpty()
+    }
+
+    @Test
+    fun `checks if an string is not instant format`() {
+        assertThat(StringCoercibleToInstant(InstantType()).validate(dataTrace(), "bad string")).containsExactly(ValidationError(dataTrace(), "could not be parsed to instant", "bad string"))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(StringCoercibleToInstant(InstantType()).validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not string`() {
+        assertThat(StringCoercibleToInstant(InstantType()).validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a string", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToInstantTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToInstantTest.kt
@@ -5,7 +5,6 @@ import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.dataTrace
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.time.Instant
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class StringCoercibleToInstantTest {

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToLongTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToLongTest.kt
@@ -1,0 +1,31 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class StringCoercibleToLongTest {
+    @Test
+    fun `passes an instant as string`() {
+        assertThat(StringCoercibleToLong(LongType()).validate(dataTrace(), "1")).isEmpty()
+    }
+
+    @Test
+    fun `checks if an string is not long format`() {
+        assertThat(StringCoercibleToLong(LongType()).validate(dataTrace(), "bad string")).containsExactly(ValidationError(dataTrace(), "could not be parsed to long", "bad string"))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(StringCoercibleToLong(LongType()).validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not string`() {
+        assertThat(StringCoercibleToLong(LongType()).validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a string", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToLongTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringCoercibleToLongTest.kt
@@ -5,7 +5,6 @@ import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.dataTrace
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.time.Instant
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class StringCoercibleToLongTest {

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringConstantTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/StringConstantTypeTest.kt
@@ -1,0 +1,21 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class StringConstantTypeTest {
+
+    @Test
+    fun `passes a constant string`() {
+        assertThat(StringConstantType("abc").validate(dataTrace(), "abc")).isEmpty()
+    }
+
+    @Test
+    fun `checks not constant`() {
+        assertThat(StringConstantType("abc").validate(dataTrace(), "")).containsExactly(ValidationError(dataTrace(), "value is not 'abc'", ""))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/UnionTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/UnionTypeTest.kt
@@ -1,0 +1,24 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class UnionTypeTest {
+
+    @Test
+    fun `passes a any union checks pass`() {
+        assertThat(UnionType(LongType(), IntType()).validate(dataTrace(), 1)).isEmpty()
+        assertThat(UnionType(LongType(), IntType()).validate(dataTrace(), 1L)).isEmpty()
+    }
+
+    @Test
+    fun `checks none union checks match`() {
+        assertThat(UnionType(LongType(), IntType()).validate(dataTrace(), "a string")).containsExactly(
+                ValidationError(dataTrace(), "is not a long", "a string"),
+                ValidationError(dataTrace(), "is not an Int", "a string"))
+    }
+}


### PR DESCRIPTION
Provide a way to generate base Baleen descriptions from legacy Avro schemas.  Additionally add the reverse generater from Baleen to Avro.

TODO
- [x] Additional Unit tests for new Baleen types created
- [x] Missing Unit tests in AvroEncoder and BaleenEncoder
- [x] Resolve some questions around "style" and naming choices
- [x] General cleanup

WONTDO (Out of scope for now)
- Missing some Avro types like "fixed"
- Missing Avro logical types like date, timestamp-micros, etc