### PR TITLE
NumericType and IntegerType

### DIFF
--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroGenerator.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroGenerator.kt
@@ -11,8 +11,10 @@ import com.shoprunner.baleen.types.EnumType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
 import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.StringConstantType
 import com.shoprunner.baleen.types.StringType
@@ -35,6 +37,8 @@ object AvroGenerator {
             is DoubleType -> Schema.create(Schema.Type.DOUBLE)
             is IntType -> Schema.create(Schema.Type.INT)
             is LongType -> Schema.create(Schema.Type.LONG)
+            is IntegerType -> Schema.create(Schema.Type.LONG)
+            is NumericType -> Schema.create(Schema.Type.DOUBLE)
             is StringType -> Schema.create(Schema.Type.STRING)
             is StringConstantType -> Schema.create(Schema.Type.STRING)
             is EnumType -> Schema.createEnum(baleenType.enumName, null, null, baleenType.enum.toList())

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroGeneratorTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroGeneratorTest.kt
@@ -13,8 +13,10 @@ import com.shoprunner.baleen.types.EnumType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
 import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.StringCoercibleToFloat
 import com.shoprunner.baleen.types.StringCoercibleToInstant
@@ -83,6 +85,18 @@ class AvroGeneratorTest {
         fun `getAvroSchema encodes long type`() {
             val schema = AvroGenerator.getAvroSchema(LongType())
             assertThat(schema.type).isEqualTo(Schema.Type.LONG)
+        }
+
+        @Test
+        fun `getAvroSchema encodes intger type`() {
+            val schema = AvroGenerator.getAvroSchema(IntegerType())
+            assertThat(schema.type).isEqualTo(Schema.Type.LONG)
+        }
+
+        @Test
+        fun `getAvroSchema encodes numeric type`() {
+            val schema = AvroGenerator.getAvroSchema(NumericType())
+            assertThat(schema.type).isEqualTo(Schema.Type.DOUBLE)
         }
 
         @Test

--- a/baleen-jsonschema-generator/src/main/kotlin/com/shoprunner/baleen/jsonschema/v3/JsonSchemaGenerator.kt
+++ b/baleen-jsonschema-generator/src/main/kotlin/com/shoprunner/baleen/jsonschema/v3/JsonSchemaGenerator.kt
@@ -21,8 +21,10 @@ import com.shoprunner.baleen.types.EnumType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
 import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.StringConstantType
 import com.shoprunner.baleen.types.StringType
@@ -67,9 +69,17 @@ object JsonSchemaGenerator {
                 maximum = baleenType.max.toDouble()
                 minimum = baleenType.min.toDouble()
             }
+            is IntegerType -> IntegerSchema().apply {
+                maximum = baleenType.max?.toDouble()
+                minimum = baleenType.min?.toDouble()
+            }
             is LongType -> IntegerSchema().apply {
                 maximum = baleenType.max.toDouble()
                 minimum = baleenType.min.toDouble()
+            }
+            is NumericType -> NumberSchema().apply {
+                maximum = baleenType.max?.toDouble()
+                minimum = baleenType.min?.toDouble()
             }
             is StringType -> StringSchema().apply {
                 maxLength = baleenType.max

--- a/baleen-jsonschema-generator/src/main/kotlin/com/shoprunner/baleen/jsonschema/v4/JsonSchemaGenerator.kt
+++ b/baleen-jsonschema-generator/src/main/kotlin/com/shoprunner/baleen/jsonschema/v4/JsonSchemaGenerator.kt
@@ -13,8 +13,10 @@ import com.shoprunner.baleen.types.EnumType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
 import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.StringConstantType
 import com.shoprunner.baleen.types.StringType
@@ -68,12 +70,16 @@ object JsonSchemaGenerator {
             is BooleanType -> BooleanSchema to objectContext
             is CoercibleType -> getJsonSchema(baleenType.type, objectContext, withAdditionalAttributes)
             is DoubleType -> NumberSchema(
-                    maximum = if (baleenType.max.isFinite()) baleenType.max else null,
-                    minimum = if (baleenType.min.isFinite()) baleenType.min else null
+                maximum = baleenType.max.takeIf { it.isFinite() }?.toBigDecimal(),
+                minimum = baleenType.min.takeIf { it.isFinite() }?.toBigDecimal()
             ) to objectContext
             is IntType -> IntegerSchema(
-                    maximum = baleenType.max.toLong(),
-                    minimum = baleenType.min.toLong()
+                maximum = baleenType.max.toBigInteger(),
+                minimum = baleenType.min.toBigInteger()
+            ) to objectContext
+            is IntegerType -> IntegerSchema(
+                maximum = baleenType.max,
+                minimum = baleenType.min
             ) to objectContext
             is EnumType -> StringSchema(
                     enum = baleenType.enum
@@ -86,13 +92,17 @@ object JsonSchemaGenerator {
                 MapSchema(additionalProperties = subSchema) to subContext
             }
             is FloatType -> NumberSchema(
-                    maximum = if (baleenType.max.isFinite()) baleenType.max.toDouble() else null,
-                    minimum = if (baleenType.min.isFinite()) baleenType.min.toDouble() else null
+                maximum = baleenType.max.takeIf { it.isFinite() }?.toBigDecimal(),
+                minimum = baleenType.min.takeIf { it.isFinite() }?.toBigDecimal()
             ) to objectContext
             is InstantType -> DateTimeSchema() to objectContext
             is LongType -> IntegerSchema(
-                    maximum = baleenType.max,
-                    minimum = baleenType.min
+                maximum = baleenType.max.toBigInteger(),
+                minimum = baleenType.min.toBigInteger()
+            ) to objectContext
+            is NumericType -> NumberSchema(
+                maximum = baleenType.max,
+                minimum = baleenType.min
             ) to objectContext
             is OccurrencesType -> {
                 val (subSchema, subContext) = getJsonSchema(baleenType.memberType, objectContext, withAdditionalAttributes)

--- a/baleen-jsonschema-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v3/JsonSchemaGeneratorTest.kt
+++ b/baleen-jsonschema-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v3/JsonSchemaGeneratorTest.kt
@@ -19,8 +19,10 @@ import com.shoprunner.baleen.types.EnumType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
 import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.StringCoercibleToFloat
 import com.shoprunner.baleen.types.StringConstantType
@@ -87,6 +89,40 @@ internal class JsonSchemaGeneratorTest {
             Assertions.assertThat(schema.isIntegerSchema).isTrue()
             Assertions.assertThat((schema as IntegerSchema).minimum).isEqualTo(Long.MIN_VALUE.toDouble())
             Assertions.assertThat(schema.maximum).isEqualTo(Long.MAX_VALUE.toDouble())
+        }
+
+        @Test
+        @Suppress("USELESS_CAST")
+        fun `getJsonSchema encodes integer type`() {
+            val schema = JsonSchemaGenerator.getJsonSchema(IntegerType())
+            Assertions.assertThat(schema.isIntegerSchema).isTrue()
+            Assertions.assertThat((schema as IntegerSchema).minimum as Double?).isNull()
+            Assertions.assertThat(schema.maximum as Double?).isNull()
+        }
+
+        @Test
+        fun `getJsonSchema encodes integer type with limits`() {
+            val schema = JsonSchemaGenerator.getJsonSchema(IntegerType(min = 0.toBigInteger(), max = 10.toBigInteger()))
+            Assertions.assertThat(schema.isIntegerSchema).isTrue()
+            Assertions.assertThat((schema as IntegerSchema).minimum).isEqualTo(0.0)
+            Assertions.assertThat(schema.maximum).isEqualTo(10.0)
+        }
+
+        @Test
+        @Suppress("USELESS_CAST")
+        fun `getJsonSchema encodes numeric type`() {
+            val schema = JsonSchemaGenerator.getJsonSchema(NumericType())
+            Assertions.assertThat(schema.isNumberSchema).isTrue()
+            Assertions.assertThat((schema as NumberSchema).minimum as Double?).isNull()
+            Assertions.assertThat(schema.maximum as Double?).isNull()
+        }
+
+        @Test
+        fun `getJsonSchema encodes numeric type with limits`() {
+            val schema = JsonSchemaGenerator.getJsonSchema(NumericType(min = 0.toBigDecimal(), max = 10.toBigDecimal()))
+            Assertions.assertThat(schema.isNumberSchema).isTrue()
+            Assertions.assertThat((schema as NumberSchema).minimum).isEqualTo(0.0)
+            Assertions.assertThat(schema.maximum).isEqualTo(10.0)
         }
 
         @Test

--- a/baleen-jsonschema-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v4/JsonSchemaGeneratorTest.kt
+++ b/baleen-jsonschema-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v4/JsonSchemaGeneratorTest.kt
@@ -12,8 +12,10 @@ import com.shoprunner.baleen.types.EnumType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
 import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.StringCoercibleToFloat
 import com.shoprunner.baleen.types.StringConstantType
@@ -265,6 +267,142 @@ internal class JsonSchemaGeneratorTest {
                       "type" : "integer",
                       "maximum" : 9223372036854775807,
                       "minimum" : -9223372036854775808
+                    }
+                  }
+                }
+              },
+              "${'$'}ref" : "#/definitions/record:Dog",
+              "${'$'}schema" : "http://json-schema.org/draft-04/schema"
+            }""".trimIndent()
+
+            val outputStream = ByteArrayOutputStream()
+            JsonSchemaGenerator.encode(description).writeTo(PrintStream(outputStream), true)
+
+            Assertions.assertThat(outputStream.toString()).isEqualToIgnoringWhitespace(schemaStr)
+        }
+
+        @Test
+        fun `getJsonSchema encodes integer type`() {
+            val description = Baleen.describe("Dog") {
+                it.attr(
+                    name = "numLegs",
+                    type = IntegerType()
+                )
+            }
+
+            val schemaStr = """
+            {
+              "id" : "Dog",
+              "definitions" : {
+                "record:Dog" : {
+                  "type" : "object",
+                  "additionalProperties": false,
+                  "properties" : {
+                    "numLegs" : {
+                      "type" : "integer"
+                    }
+                  }
+                }
+              },
+              "${'$'}ref" : "#/definitions/record:Dog",
+              "${'$'}schema" : "http://json-schema.org/draft-04/schema"
+            }""".trimIndent()
+
+            val outputStream = ByteArrayOutputStream()
+            JsonSchemaGenerator.encode(description).writeTo(PrintStream(outputStream), true)
+
+            Assertions.assertThat(outputStream.toString()).isEqualToIgnoringWhitespace(schemaStr)
+        }
+
+        @Test
+        fun `getJsonSchema encodes integer type with limits`() {
+            val description = Baleen.describe("Dog") {
+                it.attr(
+                    name = "numLegs",
+                    type = IntegerType(min = 0.toBigInteger(), max = 10.toBigInteger())
+                )
+            }
+
+            val schemaStr = """
+            {
+              "id" : "Dog",
+              "definitions" : {
+                "record:Dog" : {
+                  "type" : "object",
+                  "additionalProperties": false,
+                  "properties" : {
+                    "numLegs" : {
+                      "type" : "integer",
+                      "maximum" : 10,
+                      "minimum" : 0
+                    }
+                  }
+                }
+              },
+              "${'$'}ref" : "#/definitions/record:Dog",
+              "${'$'}schema" : "http://json-schema.org/draft-04/schema"
+            }""".trimIndent()
+
+            val outputStream = ByteArrayOutputStream()
+            JsonSchemaGenerator.encode(description).writeTo(PrintStream(outputStream), true)
+
+            Assertions.assertThat(outputStream.toString()).isEqualToIgnoringWhitespace(schemaStr)
+        }
+
+        @Test
+        fun `getJsonSchema encodes numeric type`() {
+            val description = Baleen.describe("Dog") {
+                it.attr(
+                    name = "numLegs",
+                    type = NumericType()
+                )
+            }
+
+            val schemaStr = """
+            {
+              "id" : "Dog",
+              "definitions" : {
+                "record:Dog" : {
+                  "type" : "object",
+                  "additionalProperties": false,
+                  "properties" : {
+                    "numLegs" : {
+                      "type" : "number"
+                    }
+                  }
+                }
+              },
+              "${'$'}ref" : "#/definitions/record:Dog",
+              "${'$'}schema" : "http://json-schema.org/draft-04/schema"
+            }""".trimIndent()
+
+            val outputStream = ByteArrayOutputStream()
+            JsonSchemaGenerator.encode(description).writeTo(PrintStream(outputStream), true)
+
+            Assertions.assertThat(outputStream.toString()).isEqualToIgnoringWhitespace(schemaStr)
+        }
+
+        @Test
+        fun `getJsonSchema encodes numeric type with limits`() {
+            val description = Baleen.describe("Dog") {
+                it.attr(
+                    name = "numLegs",
+                    type = NumericType(min = 0.toBigDecimal(), max = 10.toBigDecimal())
+                )
+            }
+
+            val schemaStr = """
+            {
+              "id" : "Dog",
+              "definitions" : {
+                "record:Dog" : {
+                  "type" : "object",
+                  "additionalProperties": false,
+                  "properties" : {
+                    "numLegs" : {
+                      "type" : "number",
+                      "maximum" : 10,
+                      "minimum" : 0
                     }
                   }
                 }

--- a/baleen-kotlin/README.md
+++ b/baleen-kotlin/README.md
@@ -49,9 +49,13 @@ data class Dog(
 * Double
 * Int
 * Long
+* Byte
+* Short
+* BigDecimal
+* BigInteger
 * Instant
 * Array
-* Iterable (List, Set, etc)
+* Iterable: List & Set
 * Map
 
 ## @DataTest
@@ -196,7 +200,7 @@ dog.validate(externalDogType, dataTrace("External Source"))
 
 ## TODO
 
-* Missing Data Types (enums, BigDecimal, BigInteger, LocalDate, etc.)
+* Missing Data Types (enums, LocalDate, etc.)
 * Support for annotations from popular libraries
   * Java's validation annotations - javax.validation.annotations
   * Kotlinx Serialization

--- a/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataDescriptionBuilder.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataDescriptionBuilder.kt
@@ -7,8 +7,10 @@ import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
 import com.shoprunner.baleen.types.MapType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.StringType
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -153,6 +155,10 @@ internal class DataDescriptionBuilder(
             name == "kotlin.Double" -> CodeBlock.of("%T()", DoubleType::class)
             name == "kotlin.Int" -> CodeBlock.of("%T()", IntType::class)
             name == "kotlin.Long" -> CodeBlock.of("%T()", LongType::class)
+            name == "kotlin.Byte" -> CodeBlock.of("%T(min = Byte.MIN_VALUE.toInt().toBigInteger(), max = Byte.MAX_VALUE.toInt().toBigInteger())", IntegerType::class)
+            name == "kotlin.Short" -> CodeBlock.of("%T(min = Short.MIN_VALUE.toInt().toBigInteger(), max = Short.MAX_VALUE.toInt().toBigInteger())", IntegerType::class)
+            name == "java.math.BigInteger" -> CodeBlock.of("%T()", IntegerType::class)
+            name == "java.math.BigDecimal" -> CodeBlock.of("%T()", NumericType::class)
 
             // Time Types
             name == "java.time.Instant" -> CodeBlock.of("%T()", InstantType::class)

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/BasicModelTest.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/BasicModelTest.kt
@@ -9,7 +9,9 @@ import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.StringType
 import java.time.Instant
 import org.assertj.core.api.Assertions.assertThat
@@ -80,6 +82,58 @@ internal class BasicModelTest {
             .hasNamespace("com.shoprunner.baleen.kotlin.kapt.test")
             .hasAttribute("doubleNumber", DoubleType())
             .hasAttribute("nullableDoubleNumber", AllowsNull(DoubleType()))
+
+        assertThat(model.validate().isValid()).isTrue()
+    }
+
+    @Test
+    fun `test data class with bytes produce valid data descriptions`() {
+        val model = ByteModel(1, null)
+
+        assertBaleen(model.dataDescription())
+            .hasName("ByteModel")
+            .hasNamespace("com.shoprunner.baleen.kotlin.kapt.test")
+            .hasAttribute("byteNumber", IntegerType(min = Byte.MIN_VALUE.toInt().toBigInteger(), max = Byte.MAX_VALUE.toInt().toBigInteger()))
+            .hasAttribute("nullableByteNumber", AllowsNull(IntegerType(min = Byte.MIN_VALUE.toInt().toBigInteger(), max = Byte.MAX_VALUE.toInt().toBigInteger())))
+
+        assertThat(model.validate().isValid()).isTrue()
+    }
+
+    @Test
+    fun `test data class with shorts produce valid data descriptions`() {
+        val model = ShortModel(1, null)
+
+        assertBaleen(model.dataDescription())
+            .hasName("ShortModel")
+            .hasNamespace("com.shoprunner.baleen.kotlin.kapt.test")
+            .hasAttribute("shortNumber", IntegerType(min = Short.MIN_VALUE.toInt().toBigInteger(), max = Short.MAX_VALUE.toInt().toBigInteger()))
+            .hasAttribute("nullableShortNumber", AllowsNull(IntegerType(min = Short.MIN_VALUE.toInt().toBigInteger(), max = Short.MAX_VALUE.toInt().toBigInteger())))
+
+        assertThat(model.validate().isValid()).isTrue()
+    }
+
+    @Test
+    fun `test data class with BigIntegers produce valid data descriptions`() {
+        val model = BigIntegerModel(1.toBigInteger(), null)
+
+        assertBaleen(model.dataDescription())
+            .hasName("BigIntegerModel")
+            .hasNamespace("com.shoprunner.baleen.kotlin.kapt.test")
+            .hasAttribute("bigIntegerNumber", IntegerType())
+            .hasAttribute("nullableBigIntegerNumber", AllowsNull(IntegerType()))
+
+        assertThat(model.validate().isValid()).isTrue()
+    }
+
+    @Test
+    fun `test data class with BigDecimal produce valid data descriptions`() {
+        val model = BigDecimalModel(1.0.toBigDecimal(), null)
+
+        assertBaleen(model.dataDescription())
+            .hasName("BigDecimalModel")
+            .hasNamespace("com.shoprunner.baleen.kotlin.kapt.test")
+            .hasAttribute("bigDecimalNumber", NumericType())
+            .hasAttribute("nullableBigDecimalNumber", AllowsNull(NumericType()))
 
         assertThat(model.validate().isValid()).isTrue()
     }

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/Models.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/Models.kt
@@ -1,6 +1,8 @@
 package com.shoprunner.baleen.kotlin.kapt.test
 
 import com.shoprunner.baleen.annotation.DataDescription
+import java.math.BigDecimal
+import java.math.BigInteger
 import java.time.Instant
 
 /** This is a string model */
@@ -47,6 +49,42 @@ data class DoubleModel(
 
     /** A nullable double number field */
     var nullableDoubleNumber: Double?
+)
+
+@DataDescription
+data class ByteModel(
+    /** A byte number field */
+    var byteNumber: Byte,
+
+    /** A nullable byte number field */
+    var nullableByteNumber: Byte?
+)
+
+@DataDescription
+data class ShortModel(
+    /** A short number field */
+    var shortNumber: Short,
+
+    /** A nullable short number field */
+    var nullableShortNumber: Short?
+)
+
+@DataDescription
+data class BigIntegerModel(
+    /** A BigInteger number field */
+    var bigIntegerNumber: BigInteger,
+
+    /** A nullable BigInteger number field */
+    var nullableBigIntegerNumber: BigInteger?
+)
+
+@DataDescription
+data class BigDecimalModel(
+    /** A BigDecimal number field */
+    var bigDecimalNumber: BigDecimal,
+
+    /** A nullable BigDecimal number field */
+    var nullableBigDecimalNumber: BigDecimal?
 )
 
 @DataDescription

--- a/baleen-xsd-generator/src/main/kotlin/com/shoprunner/baleen/xsd/XsdGenerator.kt
+++ b/baleen-xsd-generator/src/main/kotlin/com/shoprunner/baleen/xsd/XsdGenerator.kt
@@ -12,7 +12,9 @@ import com.shoprunner.baleen.types.EnumType
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
+import com.shoprunner.baleen.types.IntegerType
 import com.shoprunner.baleen.types.LongType
+import com.shoprunner.baleen.types.NumericType
 import com.shoprunner.baleen.types.OccurrencesType
 import com.shoprunner.baleen.types.StringType
 import com.shoprunner.baleen.types.TimestampMillisType
@@ -89,12 +91,24 @@ object XsdGenerator {
                     maxInclusive = MaxInclusive(baleenType.max.toBigDecimal()),
                     minInclusive = MinInclusive(baleenType.min.toBigDecimal()))
             ))
+            is IntegerType -> TypeDetails(simpleType = SimpleType(
+                Restriction(
+                    base = "xs:int",
+                    maxInclusive = baleenType.max?.let { MaxInclusive(it.toBigDecimal()) },
+                    minInclusive = baleenType.min?.let { MinInclusive(it.toBigDecimal()) })
+            ))
             is LongType -> TypeDetails(simpleType = SimpleType(
                                 Restriction(
                                     base = "xs:long",
                                     maxInclusive = MaxInclusive(baleenType.max.toBigDecimal()),
                                     minInclusive = MinInclusive(baleenType.min.toBigDecimal()))
                             ))
+            is NumericType -> TypeDetails(simpleType = SimpleType(
+                Restriction(
+                    base = "xs:double",
+                    maxInclusive = baleenType.max?.let { MaxInclusive(it) },
+                    minInclusive = baleenType.min?.let { MinInclusive(it) })
+            ))
             is OccurrencesType -> recursiveTypeMapper(typeMapper, baleenType.memberType).copy(maxOccurs = "unbounded")
             is CoercibleType -> recursiveTypeMapper(typeMapper, baleenType.type)
             is StringType -> TypeDetails(

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/IntegerType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/IntegerType.kt
@@ -1,0 +1,51 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationResult
+import java.math.BigInteger
+
+/**
+ * A type that can be Byte, Short, Int, Long, or BigInteger.  Less strict in typing than IntType or LongType.
+ */
+class IntegerType(val min: BigInteger? = null, val max: BigInteger? = null) : BaleenType {
+
+    override fun name(): String = "integer"
+
+    override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
+            when (value) {
+                null -> sequenceOf(ValidationError(dataTrace, "is null", value))
+                is Byte ->
+                    when {
+                        min != null && value.toInt().toBigInteger() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toInt().toBigInteger() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is Short ->
+                    when {
+                        min != null && value.toInt().toBigInteger() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toInt().toBigInteger() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is Int ->
+                    when {
+                        min != null && value.toBigInteger() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toBigInteger() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is Long ->
+                    when {
+                        min != null && value.toBigInteger() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toBigInteger() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is BigInteger ->
+                    when {
+                        min != null && value < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                else -> sequenceOf(ValidationError(dataTrace, "is not an integer", value))
+            }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/NumericType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/NumericType.kt
@@ -12,7 +12,7 @@ import java.math.BigInteger
  */
 class NumericType(val min: BigDecimal? = null, val max: BigDecimal? = null) : BaleenType {
 
-    override fun name(): String = "numeric"
+    override fun name(): String = "number"
 
     override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
             when (value) {
@@ -65,6 +65,6 @@ class NumericType(val min: BigDecimal? = null, val max: BigDecimal? = null) : Ba
                         max != null && value > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
                         else -> sequenceOf()
                     }
-                else -> sequenceOf(ValidationError(dataTrace, "is not a numeric", value))
+                else -> sequenceOf(ValidationError(dataTrace, "is not a number", value))
             }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/NumericType.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/NumericType.kt
@@ -1,0 +1,70 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.BaleenType
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationResult
+import java.math.BigDecimal
+import java.math.BigInteger
+
+/**
+ * A type that can be Byte, Short, Int, Long, BigInteger, Float, Double, or BigDecimal.  Least strict of any numeric types
+ */
+class NumericType(val min: BigDecimal? = null, val max: BigDecimal? = null) : BaleenType {
+
+    override fun name(): String = "numeric"
+
+    override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
+            when (value) {
+                null -> sequenceOf(ValidationError(dataTrace, "is null", value))
+                is Byte ->
+                    when {
+                        min != null && value.toInt().toBigDecimal() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toInt().toBigDecimal() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is Short ->
+                    when {
+                        min != null && value.toInt().toBigDecimal() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toInt().toBigDecimal() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is Int ->
+                    when {
+                        min != null && value.toBigDecimal() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toBigDecimal() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is Long ->
+                    when {
+                        min != null && value.toBigDecimal() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toBigDecimal() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is BigInteger ->
+                    when {
+                        min != null && value.toBigDecimal() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toBigDecimal() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is Float ->
+                    when {
+                        min != null && value.toBigDecimal() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toBigDecimal() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is Double ->
+                    when {
+                        min != null && value.toBigDecimal() < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value.toBigDecimal() > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                is BigDecimal ->
+                    when {
+                        min != null && value < min -> sequenceOf(ValidationError(dataTrace, "is less than $min", value))
+                        max != null && value > max -> sequenceOf(ValidationError(dataTrace, "is greater than $max", value))
+                        else -> sequenceOf()
+                    }
+                else -> sequenceOf(ValidationError(dataTrace, "is not a numeric", value))
+            }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/SequenceAssert.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/SequenceAssert.kt
@@ -4,20 +4,23 @@ import org.assertj.core.api.AbstractAssert
 
 class SequenceAssert<T>(actual: Sequence<T>) : AbstractAssert<SequenceAssert<T>, Sequence<T>>(actual, SequenceAssert::class.java) {
 
+    private val actualList = actual.toList()
+
     companion object {
         fun <T> assertThat(actual: Sequence<T>) = SequenceAssert(actual)
     }
 
     fun isEmpty(): SequenceAssert<T> {
-        if (actual.toList().isNotEmpty()) {
-            failWithMessage("sequence <%s> is not empty", actual)
+        if (actualList.isNotEmpty()) {
+            failWithMessage("sequence <%s> is not empty", actualList)
         }
         return this
     }
 
     fun containsExactly(vararg match: T): SequenceAssert<T> {
-        if (!actual.zip(match.asSequence()).all { (a, e) -> a == e }) {
-            failWithMessage("sequence <%s> is not the same as", match)
+        val matchList = match.toList()
+        if (!actualList.zip(matchList).all { (a, e) -> a == e }) {
+            failWithMessage("sequence <%s> is not the same as <%s>", actualList, matchList)
         }
         return this
     }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/IntegerTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/IntegerTypeTest.kt
@@ -1,0 +1,116 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class IntegerTypeTest {
+
+    @Test
+    fun `passes a Byte`() {
+        assertThat(IntegerType().validate(dataTrace(), 0.toByte())).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Byte`() {
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 0.toByte())).containsExactly(ValidationError(dataTrace(), "is less than 1", 0.toByte()))
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 1.toByte())).isEmpty()
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 2.toByte())).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Byte`() {
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 0.toByte())).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 1.toByte())).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 2.toByte())).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2.toByte()))
+    }
+
+    @Test
+    fun `passes a Short`() {
+        assertThat(IntegerType().validate(dataTrace(), 0.toShort())).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Short`() {
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 0.toShort())).containsExactly(ValidationError(dataTrace(), "is less than 1", 0.toShort()))
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 1.toShort())).isEmpty()
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 2.toShort())).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Short`() {
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 0.toShort())).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 1.toShort())).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 2.toShort())).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2.toShort()))
+    }
+
+    @Test
+    fun `passes a Int`() {
+        assertThat(IntegerType().validate(dataTrace(), 0)).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Int`() {
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 0)).containsExactly(ValidationError(dataTrace(), "is less than 1", 0))
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 1)).isEmpty()
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 2)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Int`() {
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 0)).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 1)).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 2)).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2))
+    }
+
+    @Test
+    fun `passes a Long`() {
+        assertThat(IntegerType().validate(dataTrace(), 0L)).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Long`() {
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 0L)).containsExactly(ValidationError(dataTrace(), "is less than 1", 0L))
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 1L)).isEmpty()
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 2L)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Long`() {
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 0L)).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 1L)).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 2L)).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2L))
+    }
+
+    @Test
+    fun `passes a BigInteger`() {
+        assertThat(IntegerType().validate(dataTrace(), 0.toBigInteger())).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for BigInteger`() {
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 0L.toBigInteger())).containsExactly(ValidationError(dataTrace(), "is less than 1", 0L.toBigInteger()))
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 1L.toBigInteger())).isEmpty()
+        assertThat(IntegerType(min = 1.toBigInteger()).validate(dataTrace(), 2L.toBigInteger())).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for BigInteger`() {
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 0L.toBigInteger())).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 1L.toBigInteger())).isEmpty()
+        assertThat(IntegerType(max = 1.toBigInteger()).validate(dataTrace(), 2L.toBigInteger())).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2L.toBigInteger()))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(IntegerType().validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not integer`() {
+        assertThat(IntegerType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not an integer", false))
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/NumericTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/NumericTypeTest.kt
@@ -170,6 +170,6 @@ internal class NumericTypeTest {
 
     @Test
     fun `checks not numeric`() {
-        assertThat(NumericType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a numeric", false))
+        assertThat(NumericType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a number", false))
     }
 }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/NumericTypeTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/NumericTypeTest.kt
@@ -1,0 +1,175 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat as assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationInfo
+import com.shoprunner.baleen.dataTrace
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class NumericTypeTest {
+    @Test
+    fun `passes a Double`() {
+        assertThat(NumericType().validate(dataTrace(), 0.0)).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Double`() {
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 0.0)).containsExactly(ValidationError(dataTrace(), "is less than 1.0", 0.0))
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 1.0)).isEmpty()
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 2.0)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Double`() {
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 0.0)).isEmpty()
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 1.0)).isEmpty()
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 2.0)).containsExactly(ValidationError(dataTrace(), "is greater than 1.0", 2.0))
+    }
+
+    @Test
+    fun `passes a Float`() {
+        assertThat(NumericType().validate(dataTrace(), 0.0F)).containsExactly(
+            ValidationInfo(dataTrace(), message = "is coerced to double from Float", value = 0.0F)
+        )
+    }
+
+    @Test
+    fun `checks minimum value for Float`() {
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 0.0F)).containsExactly(ValidationError(dataTrace(), "is less than 1.0", 0.0F))
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 1.0F)).isEmpty()
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 2.0F)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Float`() {
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 0.0F)).isEmpty()
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 1.0F)).isEmpty()
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 2.0F)).containsExactly(ValidationError(dataTrace(), "is greater than 1.0", 2.0F))
+    }
+
+    @Test
+    fun `passes a BigDecimal`() {
+        assertThat(NumericType().validate(dataTrace(), 0.0.toBigDecimal())).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for BigDecimal`() {
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 0.0.toBigDecimal())).containsExactly(ValidationError(dataTrace(), "is less than 1.0", 0.0.toBigDecimal()))
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 1.0.toBigDecimal())).isEmpty()
+        assertThat(NumericType(min = 1.0.toBigDecimal()).validate(dataTrace(), 2.0.toBigDecimal())).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for BigDecimal`() {
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 0.0.toBigDecimal())).isEmpty()
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 1.0.toBigDecimal())).isEmpty()
+        assertThat(NumericType(max = 1.0.toBigDecimal()).validate(dataTrace(), 2.0.toBigDecimal())).containsExactly(ValidationError(dataTrace(), "is greater than 1.0", 2.0.toBigDecimal()))
+    }
+
+    @Test
+    fun `passes a Byte`() {
+        assertThat(NumericType().validate(dataTrace(), 0.toByte())).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Byte`() {
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 0.toByte())).containsExactly(ValidationError(dataTrace(), "is less than 1", 0.toByte()))
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 1.toByte())).isEmpty()
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 2.toByte())).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Byte`() {
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 0.toByte())).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 1.toByte())).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 2.toByte())).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2.toByte()))
+    }
+
+    @Test
+    fun `passes a Short`() {
+        assertThat(NumericType().validate(dataTrace(), 0.toShort())).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Short`() {
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 0.toShort())).containsExactly(ValidationError(dataTrace(), "is less than 1", 0.toShort()))
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 1.toShort())).isEmpty()
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 2.toShort())).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Short`() {
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 0.toShort())).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 1.toShort())).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 2.toShort())).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2.toShort()))
+    }
+
+    @Test
+    fun `passes a Int`() {
+        assertThat(NumericType().validate(dataTrace(), 0)).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Int`() {
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 0)).containsExactly(ValidationError(dataTrace(), "is less than 1", 0))
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 1)).isEmpty()
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 2)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Int`() {
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 0)).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 1)).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 2)).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2))
+    }
+
+    @Test
+    fun `passes a Long`() {
+        assertThat(NumericType().validate(dataTrace(), 0L)).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for Long`() {
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 0L)).containsExactly(ValidationError(dataTrace(), "is less than 1", 0L))
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 1L)).isEmpty()
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 2L)).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for Long`() {
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 0L)).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 1L)).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 2L)).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2L))
+    }
+
+    @Test
+    fun `passes a BigInteger`() {
+        assertThat(NumericType().validate(dataTrace(), 0.toBigInteger())).isEmpty()
+    }
+
+    @Test
+    fun `checks minimum value for BigInteger`() {
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 0L.toBigInteger())).containsExactly(ValidationError(dataTrace(), "is less than 1", 0L.toBigInteger()))
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 1L.toBigInteger())).isEmpty()
+        assertThat(NumericType(min = 1.toBigDecimal()).validate(dataTrace(), 2L.toBigInteger())).isEmpty()
+    }
+
+    @Test
+    fun `checks maximum value for BigInteger`() {
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 0L.toBigInteger())).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 1L.toBigInteger())).isEmpty()
+        assertThat(NumericType(max = 1.toBigDecimal()).validate(dataTrace(), 2L.toBigInteger())).containsExactly(ValidationError(dataTrace(), "is greater than 1", 2L.toBigInteger()))
+    }
+
+    @Test
+    fun `checks null`() {
+        assertThat(NumericType().validate(dataTrace(), null)).containsExactly(ValidationError(dataTrace(), "is null", null))
+    }
+
+    @Test
+    fun `checks not numeric`() {
+        assertThat(NumericType().validate(dataTrace(), false)).containsExactly(ValidationError(dataTrace(), "is not a numeric", false))
+    }
+}

--- a/jsonschema-baleen-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v4/BaleenGeneratorTest.kt
+++ b/jsonschema-baleen-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v4/BaleenGeneratorTest.kt
@@ -220,12 +220,12 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.DoubleType
+                import com.shoprunner.baleen.types.NumericType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "number",
-                            type = DoubleType()
+                            type = NumericType()
                     )
                 }
             """.trimIndent()
@@ -240,7 +240,7 @@ internal class BaleenGeneratorTest {
         }
 
         @Test
-        fun `json number with min and max converts to double in Baleen`() {
+        fun `json number with min and max converts to numeric in Baleen`() {
             val schemaStr = """
             {
               "id" : "Dog",
@@ -264,12 +264,12 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.DoubleType
+                import com.shoprunner.baleen.types.NumericType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "number",
-                            type = DoubleType(0.0, 100.0)
+                            type = NumericType(min = 0.toBigDecimal(), max = 100.toBigDecimal())
                     )
                 }
             """.trimIndent()
@@ -307,12 +307,12 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.DoubleType
+                import com.shoprunner.baleen.types.NumericType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "number",
-                            type = DoubleType(),
+                            type = NumericType(),
                             default = 1.1
                     )
                 }
@@ -350,12 +350,12 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "numLegs",
-                            type = LongType()
+                            type = IntegerType()
                     )
                 }
             """.trimIndent()
@@ -394,12 +394,12 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "numLegs",
-                            type = LongType(0, 100)
+                            type = IntegerType(min = 0.toBigInteger(), max = 100.toBigInteger())
                     )
                 }
             """.trimIndent()
@@ -437,12 +437,12 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "numLegs",
-                            type = LongType(),
+                            type = IntegerType(),
                             default = 10L
                     )
                 }
@@ -885,14 +885,14 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
                 import com.shoprunner.baleen.types.StringType
                 import com.shoprunner.baleen.types.UnionType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "num_legs",
-                            type = UnionType(StringType(), LongType())
+                            type = UnionType(StringType(), IntegerType())
                     )
                 }
             """.trimIndent()
@@ -936,14 +936,14 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
                 import com.shoprunner.baleen.types.StringType
                 import com.shoprunner.baleen.types.UnionType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "num_legs",
-                            type = UnionType(StringType(), LongType())
+                            type = UnionType(StringType(), IntegerType())
                     )
                 }
             """.trimIndent()
@@ -1050,13 +1050,19 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
                 import com.shoprunner.baleen.types.UnionType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "num_legs",
-                            type = UnionType(LongType(), LongType())
+                            type = UnionType(
+                                IntegerType(), 
+                                IntegerType(
+                                    min = -9223372036854775808.toBigInteger(), 
+                                    max = 9223372036854775807.toBigInteger()
+                                )
+                            )
                     )
                 }
             """.trimIndent()
@@ -1104,13 +1110,22 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
                 import com.shoprunner.baleen.types.UnionType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                         name = "num_legs",
-                        type = UnionType(LongType(-2147483648, 2147483647), LongType())
+                        type = UnionType(
+                            IntegerType(
+                                min = -2147483648.toBigInteger(), 
+                                max = 2147483647.toBigInteger()
+                            ), 
+                            IntegerType(
+                                min = -9223372036854775808.toBigInteger(), 
+                                max = 9223372036854775807.toBigInteger()
+                            )
+                        )
                     )
                 }
             """.trimIndent()
@@ -1151,12 +1166,12 @@ internal class BaleenGeneratorTest {
             val descriptionStr = """
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "num_legs",
-                            type = LongType()
+                            type = IntegerType()
                     )
                 }
             """.trimIndent()
@@ -1201,12 +1216,12 @@ internal class BaleenGeneratorTest {
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
                 import com.shoprunner.baleen.types.AllowsNull
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "num_legs",
-                            type = AllowsNull(LongType())
+                            type = AllowsNull(IntegerType())
                     )
                 }
             """.trimIndent()
@@ -1252,12 +1267,12 @@ internal class BaleenGeneratorTest {
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
                 import com.shoprunner.baleen.types.AllowsNull
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
 
                 val Dog: DataDescription = describe("Dog", "", "") {
                     it.attr(
                             name = "num_legs",
-                            type = AllowsNull(LongType()),
+                            type = AllowsNull(IntegerType()),
                             default = null
                     )
                 }
@@ -1332,7 +1347,7 @@ internal class BaleenGeneratorTest {
 
                 import com.shoprunner.baleen.Baleen.describe
                 import com.shoprunner.baleen.DataDescription
-                import com.shoprunner.baleen.types.LongType
+                import com.shoprunner.baleen.types.IntegerType
                 import com.shoprunner.baleen.types.StringType
 
                 /**
@@ -1346,7 +1361,7 @@ internal class BaleenGeneratorTest {
                     )
                     it.attr(
                             name = "num_legs",
-                            type = LongType(),
+                            type = IntegerType(),
                             markdownDescription = "The number of legs a dog has",
                             default = 4L
                     )

--- a/jsonschema-model/src/main/kotlin/com/shoprunner/baleen/jsonschema/v4/IntegerSchema.kt
+++ b/jsonschema-model/src/main/kotlin/com/shoprunner/baleen/jsonschema/v4/IntegerSchema.kt
@@ -1,8 +1,10 @@
 package com.shoprunner.baleen.jsonschema.v4
 
+import java.math.BigInteger
+
 data class IntegerSchema(
-    val maximum: Long? = null,
-    val minimum: Long? = null
+    val maximum: BigInteger? = null,
+    val minimum: BigInteger? = null
 ) : JsonSchema() {
     val type = JsonType.integer
 }

--- a/jsonschema-model/src/main/kotlin/com/shoprunner/baleen/jsonschema/v4/NumberSchema.kt
+++ b/jsonschema-model/src/main/kotlin/com/shoprunner/baleen/jsonschema/v4/NumberSchema.kt
@@ -1,8 +1,10 @@
 package com.shoprunner.baleen.jsonschema.v4
 
+import java.math.BigDecimal
+
 data class NumberSchema(
-    val maximum: Double? = null,
-    val minimum: Double? = null
+    val maximum: BigDecimal? = null,
+    val minimum: BigDecimal? = null
 ) : JsonSchema() {
     val type = JsonType.number
 }


### PR DESCRIPTION
In response to #41 where it was decided to support new numeric Baleen types rather than have implicit conversion of one number type to another (int -> long for example).  Json validation has a need for BigInteger and BigDecimal support since JSON doesn't have size maximums which means a string backed type like BigDecimail need to be used. It also doesn't know how to downgrade to say Int or Float from the larger size.

**IntegerType** - Supports integer types Byte, Short, Int, Long, BigInteger.
**NumericType** - Supports all numeric types Byte, Short, Int, Long, BigInteger and also Float, Double, and BigDecimal.

Made changes in core Baleen as well as the generators that may need to use it.