### PR TITLE
Renaming fields and alias support for data class schemas

### DIFF
--- a/baleen-kotlin/README.md
+++ b/baleen-kotlin/README.md
@@ -85,6 +85,35 @@ fun assert3orMoreLegs(dog: Dog, dataTrace: DataTrace = dataTrace()): Sequence<Va
 }
 ```
 
+## @Name
+
+Overrides the attribute name in the data. Without the annotation by default the field's name is used.  Different than @Alias since the original
+attribute name is no longer used.
+
+```kotlin
+@DataDescription
+data class ModelWithDifferentFieldNames(
+    @Name("field_name")
+    var fieldName: String
+)
+```
+
+## @Alias
+
+Specifies additional attribute names that the data responds to. Useful for backwards compatibility when field names
+change.
+
+```kotlin
+@DataDescription
+data class ModelWithAliases(
+    @Alias("field_name")
+    var fieldName: String,
+
+    @Alias("another_name1", "another_name2")
+    var anotherName: String
+)
+```
+
 ## Generated files
 
 Gradle task `kotlinKapt` is called before `kotlinCompile`. When called, Each data class adds two files, 

--- a/baleen-kotlin/baleen-kotlin-api/src/main/kotlin/com/shoprunner/baleen/annotation/Alias.kt
+++ b/baleen-kotlin/baleen-kotlin-api/src/main/kotlin/com/shoprunner/baleen/annotation/Alias.kt
@@ -1,0 +1,14 @@
+package com.shoprunner.baleen.annotation
+
+/**
+ * Specify additional names that the field can have in the data.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FIELD)
+@MustBeDocumented
+annotation class Alias(
+    /**
+     * The aliases
+     */
+    vararg val value: String
+)

--- a/baleen-kotlin/baleen-kotlin-api/src/main/kotlin/com/shoprunner/baleen/annotation/Name.kt
+++ b/baleen-kotlin/baleen-kotlin-api/src/main/kotlin/com/shoprunner/baleen/annotation/Name.kt
@@ -1,0 +1,15 @@
+package com.shoprunner.baleen.annotation
+
+/**
+ * Specify the name that the field has in the data. Overrides the field name in the class.
+ * Use @Alias for additional names.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FIELD)
+@MustBeDocumented
+annotation class Name(
+    /**
+     * The name of the field in the data
+     */
+    val value: String
+)

--- a/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataDescriptionBuilder.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataDescriptionBuilder.kt
@@ -1,6 +1,8 @@
 package com.shoprunner.baleen.kapt
 
 import com.shoprunner.baleen.Baleen
+import com.shoprunner.baleen.annotation.Alias
+import com.shoprunner.baleen.annotation.Name
 import com.shoprunner.baleen.types.AllowsNull
 import com.shoprunner.baleen.types.BooleanType
 import com.shoprunner.baleen.types.DoubleType
@@ -102,7 +104,7 @@ internal class DataDescriptionBuilder(
             // name
             add(
                 "name = %S,\n",
-                attrName
+                param.getAnnotation(Name::class.java)?.value ?: attrName
             )
             // type
             add("type = ")
@@ -120,13 +122,13 @@ internal class DataDescriptionBuilder(
                 add("markdownDescription = %S,\n", comment)
             }
             // aliases
-            val aliases = emptyArray<String>()
+            val aliases = param.getAnnotation(Alias::class.java)?.value ?: emptyArray()
             if (aliases.isNotEmpty()) {
                 add(
                     // "%L = %L,\n",
                     // com.shoprunner.baleen.DataDescription::attr.parameters[4].name,
                     "aliases = %L,\n",
-                    aliases.joinToString(", ", prefix = "arrayOf(\"", postfix = "\")")
+                    aliases.joinToString("\", \"", prefix = "arrayOf(\"", postfix = "\")")
                 )
             }
             // required always set from data classes by default

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/AliasTest.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/AliasTest.kt
@@ -1,0 +1,25 @@
+package com.shoprunner.baleen.kotlin.kapt.test
+
+import com.shoprunner.baleen.kotlin.dataDescription
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AliasTest {
+
+    @Test
+    fun `test that field names have aliases`() {
+        val model = ModelWithAliases("field1", "field2")
+
+        DataDescriptionAssert.assertBaleen(model.dataDescription())
+            .hasName("ModelWithAliases")
+            .hasAttribute("fieldName") {
+                AttributeDescriptionAssert.assertThat(it)
+                    .hasAlias("field_name")
+            }
+            .hasAttribute("anotherName") {
+                AttributeDescriptionAssert.assertThat(it)
+                    .hasAlias("another_name1", "another_name2")
+            }
+    }
+}

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/DataDescriptionGenerationTest.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/DataDescriptionGenerationTest.kt
@@ -20,8 +20,16 @@ internal class DataDescriptionGenerationTest {
             .hasName("StringModel")
             .hasNamespace("com.shoprunner.baleen.kotlin.kapt.test")
             .hasMarkdownDescription("This is a string model")
-            .hasAttribute("string", StringType(), "A string field")
-            .hasAttribute("nullableString", AllowsNull(StringType()), "A nullable string field")
+            .hasAttribute("string") {
+                AttributeDescriptionAssert.assertThat(it)
+                    .hasType(StringType())
+                    .hasMarkdownDescription("A string field")
+            }
+            .hasAttribute("nullableString") {
+                AttributeDescriptionAssert.assertThat(it)
+                    .hasType(AllowsNull(StringType()))
+                    .hasMarkdownDescription("A nullable string field")
+            }
 
         assertThat(model.validate().isValid()).isTrue()
     }
@@ -34,8 +42,16 @@ internal class DataDescriptionGenerationTest {
             .hasName("ManuallyNamed")
             .hasNamespace("com.shoprunner.baleen.kotlin.different")
             .hasMarkdownDescription("This is a string model")
-            .hasAttribute("string", StringType(), "A string field")
-            .hasAttribute("nullableString", AllowsNull(StringType()), "A nullable string field")
+            .hasAttribute("string") {
+                AttributeDescriptionAssert.assertThat(it)
+                    .hasType(StringType())
+                    .hasMarkdownDescription("A string field")
+            }
+            .hasAttribute("nullableString") {
+                AttributeDescriptionAssert.assertThat(it)
+                    .hasType(AllowsNull(StringType()))
+                    .hasMarkdownDescription("A nullable string field")
+            }
 
         assertThat(model.validate().isValid()).isTrue()
     }

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/DifferentFieldNameTest.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/DifferentFieldNameTest.kt
@@ -1,0 +1,18 @@
+package com.shoprunner.baleen.kotlin.kapt.test
+
+import com.shoprunner.baleen.kotlin.dataDescription
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class DifferentFieldNameTest {
+
+    @Test
+    fun `test that field names are renamed`() {
+        val model = ModelWithDifferentFieldNames("field name")
+
+        DataDescriptionAssert.assertBaleen(model.dataDescription())
+            .hasName("ModelWithDifferentFieldNames")
+            .hasAttribute("field_name")
+    }
+}

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/Models.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/Models.kt
@@ -1,6 +1,8 @@
 package com.shoprunner.baleen.kotlin.kapt.test
 
+import com.shoprunner.baleen.annotation.Alias
 import com.shoprunner.baleen.annotation.DataDescription
+import com.shoprunner.baleen.annotation.Name
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.Instant
@@ -260,4 +262,19 @@ data class StringModelWithOverriddenName(
 
     /** A nullable string field **/
     var nullableString: String?
+)
+
+@DataDescription
+data class ModelWithDifferentFieldNames(
+    @Name("field_name")
+    var fieldName: String
+)
+
+@DataDescription
+data class ModelWithAliases(
+    @Alias("field_name")
+    var fieldName: String,
+
+    @Alias("another_name1", "another_name2")
+    var anotherName: String
 )


### PR DESCRIPTION
Introduces two annotations `@Name` and `@Alias` that help data classes refine the Baleen data descriptions. This is useful when the data classes are the source of the truth.

## @ Name

 Overrides the attribute name in the data. Without the annotation by default the field's name is used.  Different than `@Alias` since the original
attribute name is no longer used.

 ```kotlin
@DataDescription
data class ModelWithDifferentFieldNames(
    @Name("field_name")
    var fieldName: String
)
```
becomes
```kotlin
val ModelWithDifferentFieldNamesType: DataDescription =
    Baleen.describe("ModelWithDifferentFieldNames", "com.shoprunner.baleen.kotlin.kapt.test") {

      it.attr(
        name = "field_name",
        type = StringType(),
        required = true
      )
    }
```

 ## @ Alias

 Specifies additional attribute names that the data responds to. Useful for backwards compatibility when field names
change.

 ```kotlin
@DataDescription
data class ModelWithAliases(
    @Alias("field_name")
    var fieldName: String,

    @Alias("another_name1", "another_name2")
    var anotherName: String
)
```
becomes
```kotlin
val ModelWithAliasesType: DataDescription = Baleen.describe("ModelWithAliases",
    "com.shoprunner.baleen.kotlin.kapt.test") {

      it.attr(
        name = "fieldName",
        type = StringType(),
        aliases = arrayOf("field_name"),
        required = true
      )

      it.attr(
        name = "anotherName",
        type = StringType(),
        aliases = arrayOf("another_name1", "another_name2"),
        required = true
      )
    }
```