### PR TITLE
Support less strict nullable schema mapping for Baleen -> Avro schema

### DIFF
--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroGenerator.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroGenerator.kt
@@ -71,7 +71,7 @@ object AvroGenerator {
         }
     }
 
-    fun encode(dataDescription: DataDescription): Schema {
+    fun encode(dataDescription: DataDescription, options: Options = Options()): Schema {
         val fields = dataDescription.attrs.map { attr ->
             if (!attr.required && attr.default == NoDefault) {
                 throw IllegalArgumentException("Optional value without the required default value for ${attr.name}")

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/Options.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/Options.kt
@@ -1,0 +1,11 @@
+package com.shoprunner.baleen.avro
+
+/**
+ * Options to encode Baleen DataDescription to Avro Schemas.
+ */
+data class Options(
+    /**
+     * When set to true, any nullable field will be set to null unless a default already exists.
+     */
+    val nullableFieldsAutomaticallyDefaultToNull: Boolean = false
+)


### PR DESCRIPTION
When using data class as the schema, the data classes can hae nullable fields but the default values cannot be set.  This means that combining with the Avro schema generator, the avro schemas are invalid since it requires a default type of null.  This PR provides an option to the Avro generator to default to null when the field is nullable or optional.