### PR TITLE
Support Model classes that contain companion objects when generating DataDescriptions

### DIFF
--- a/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataClassExtensionBuilder.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataClassExtensionBuilder.kt
@@ -16,6 +16,8 @@ import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.toImmutableKmClass
 import java.io.File
 import java.util.SortedSet
 import javax.annotation.processing.Messager
@@ -34,6 +36,7 @@ internal class DataClassExtensionBuilder(
     private val typeUtils: Types,
     private val messager: Messager
 ) {
+    @KotlinPoetMetadataPreview
     fun generateExtensionFile(
         dataDescriptionElement: DataDescriptionElement,
         allSchemas: Map<String, DataDescriptionElement>
@@ -42,6 +45,7 @@ internal class DataClassExtensionBuilder(
 
         val members = (typeElement.enclosedElements ?: emptyList<Element>())
             .filter { it.kind == ElementKind.FIELD }
+            .filter { m -> typeElement.toImmutableKmClass().properties.any { it.name == m.simpleName.toString() } }
 
         val commonPackagePrefix = allSchemas.values
             .map {

--- a/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataDescriptionBuilder.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataDescriptionBuilder.kt
@@ -24,6 +24,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.toImmutableKmClass
 import java.io.File
 import javax.annotation.processing.Messager
 import javax.lang.model.element.Element
@@ -55,6 +56,7 @@ internal class DataDescriptionBuilder(
         val fileName = "${name.capitalize()}Type"
         val members = (typeElement.enclosedElements ?: emptyList<Element>())
             .filter { it.kind == ElementKind.FIELD }
+            .filter { m -> typeElement.toImmutableKmClass().properties.any { it.name == m.simpleName.toString() } }
 
         val defaultValueContainer = typeElement.defaultValues()
 

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/BasicModelTest.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/BasicModelTest.kt
@@ -163,4 +163,16 @@ internal class BasicModelTest {
 
         assertThat(model.validate().isValid()).isTrue()
     }
+
+    @Test
+    fun `test data class won't serialize companion object`() {
+        val model = ModelWithCompanionObject("hello")
+
+        assertBaleen(model.dataDescription())
+            .hasName("ModelWithCompanionObject")
+            .hasNamespace("com.shoprunner.baleen.kotlin.kapt.test")
+            .hasAttribute("message", StringType())
+
+        assertThat(model.validate().isValid()).isTrue()
+    }
 }

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/Models.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/Models.kt
@@ -348,3 +348,10 @@ data class ModelWithDefaultValues(
 data class SubModelWithDefaults(
     val str: String = "test"
 )
+
+@DataDescription
+data class ModelWithCompanionObject(val message: String) {
+    companion object {
+        val message: String = "Hello"
+    }
+}


### PR DESCRIPTION
Ignore the fields in the companion classes

I was trying Baleen `@DataDescription` annotation alongside `@Serializable` in the avro4k library. Turns out that avro4k appends a Companion object to handle serialization and Baleen Kapt was generating fields for the items in the companion object. Rather I would just like to ignore them.


```kotlin
@DataDescription
data class ModelWithCompanionObject(val message: String) {
    companion object {
        val message: String = "Hello"
    }
}
```

Should generate 
```kotlin
val ModelWithCompanionObjectType: DataDescription = Baleen.describe("ModelWithCompanionObject", "com.shoprunner.baleen.kotlin.kapt.test") {
      it.attr(
        name = "message",
        type = StringType(),
        required = true
      )
}
```

But instead was generating 
```kotlin
val ModelWithCompanionObjectType: DataDescription = Baleen.describe("ModelWithCompanionObject", "com.shoprunner.baleen.kotlin.kapt.test") {
      it.attr(
        name = "message",
        type = StringType(),
        required = true
      )

     it.attr(
        name = "message${'$'}",
        type = StringType(),
        required = true
      )
}
```