### PR TITLE
Fix bug to handle empty text nodes in XML Validation

### DIFF
--- a/baleen-xml/src/test/kotlin/com/shoprunner/baleen/xml/XmlUtilTest.kt
+++ b/baleen-xml/src/test/kotlin/com/shoprunner/baleen/xml/XmlUtilTest.kt
@@ -77,6 +77,27 @@ internal class XmlUtilTest {
             )
     }
 
+    @Test
+    fun `attributeDataValue handles empty text nodes`() {
+        val inputStream = """
+            <pack>
+                <dog></dog>
+            </pack>
+            """.trimIndent().byteInputStream()
+
+        val context = XmlUtil.fromXmlToContext(dataTrace(), inputStream)
+        assertThat(context.data.attributeDataValue("pack", dataTrace()).value).isInstanceOf(Data::class.java)
+        val data = context.data.attributeDataValue("pack", dataTrace()).value as Data
+        assertThat(data.attributeDataValue("dog", dataTrace()))
+            .isEqualTo(
+                DataValue(
+                    value = "",
+                    dataTrace = dataTrace("attribute \"dog\"")
+                        .tag("line", "2")
+                        .tag("column", "10"))
+            )
+    }
+
     @Nested
     inner class MultipleOccurences {
         private val multipleOccurrences = """


### PR DESCRIPTION
The case of `dog` being an empty text node was broken and wasn't being set as empty string. Instead it was a map.

```xml
<pack>
    <dog></dog>
</pack>
```

Added unit test and fix.

Note: This trims the text. Below also returns empty string.  This is a separate bug in Baleen.
```xml
<pack>
    <dog>               </dog>
</pack>
