### PR TITLE
Fix ability to add warnings or override errors to warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,41 @@ val productDescription = "Product".describeAs {
 }
 ```
 
+### Warnings
+
+Sometimes you will want an attribute or type to warn instead of error. The `asWarnings()` method will transform the output
+from `ValidationError` to `ValidationWarning` for all nested tests run underneath that attribute/type.
+
+```kotlin
+import com.shoprunner.baleen.Baleen.describeAs
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.dataTrace
+import com.shoprunner.baleen.types.StringType
+import com.shoprunner.baleen.types.asWarning()
+
+
+val productDescription = "Product".describeAs {
+
+    // The asWarning() method is on StringType. Min/max are warnings, but required is still an error.
+    "sku".type(StringType(min = 1, max = 500).asWarning(), required = true) 
+
+    // The asWarning() method is on the attribute. Min/max and required are all warnings.
+    "brand_manufacturer".type(StringType(min = 1, max = 500), required = true).asWarning()
+
+    // That asWarning() method is on the attribute. The attribute's custom test will also be turned into a warning.
+    "department".type(StringType(min = 0, max = 100)).describe { attr ->
+
+        attr.test { datatrace, value ->
+            val department = value["department"]
+            if (department != null && !departments.contains(department)) {
+                sequenceOf(ValidationError(dataTrace, "Department ($department) is not a valid value.", value))
+            } else {
+                sequenceOf()
+            }
+        }
+    }.asWarning()
+}
+```
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -116,16 +116,16 @@ import com.shoprunner.baleen.Baleen.describeAs
 import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.dataTrace
 import com.shoprunner.baleen.types.StringType
-import com.shoprunner.baleen.types.asWarning()
+import com.shoprunner.baleen.types.asWarnings
 
 
 val productDescription = "Product".describeAs {
 
     // The asWarning() method is on StringType. Min/max are warnings, but required is still an error.
-    "sku".type(StringType(min = 1, max = 500).asWarning(), required = true) 
+    "sku".type(StringType(min = 1, max = 500).asWarnings(), required = true) 
 
     // The asWarning() method is on the attribute. Min/max and required are all warnings.
-    "brand_manufacturer".type(StringType(min = 1, max = 500), required = true).asWarning()
+    "brand_manufacturer".type(StringType(min = 1, max = 500), required = true).asWarnings()
 
     // That asWarning() method is on the attribute. The attribute's custom test will also be turned into a warning.
     "department".type(StringType(min = 0, max = 100)).describe { attr ->
@@ -138,7 +138,7 @@ val productDescription = "Product".describeAs {
                 sequenceOf()
             }
         }
-    }.asWarning()
+    }.asWarnings()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ import com.shoprunner.baleen.types.asWarnings
 
 val productDescription = "Product".describeAs {
 
-    // The asWarning() method is on StringType. Min/max are warnings, but required is still an error.
+    // The asWarnings() method is on StringType. Min/max are warnings, but required is still an error.
     "sku".type(StringType(min = 1, max = 500).asWarnings(), required = true) 
 
-    // The asWarning() method is on the attribute. Min/max and required are all warnings.
+    // The asWarnings() method is on the attribute. Min/max and required are all warnings.
     "brand_manufacturer".type(StringType(min = 1, max = 500), required = true).asWarnings()
 
-    // That asWarning() method is on the attribute. The attribute's custom test will also be turned into a warning.
+    // The asWarnings() method is on the attribute. The attribute's custom test will also be turned into a warning.
     "department".type(StringType(min = 0, max = 100)).describe { attr ->
 
         attr.test { datatrace, value ->

--- a/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroGenerator.kt
+++ b/baleen-avro-generator/src/main/kotlin/com/shoprunner/baleen/avro/AvroGenerator.kt
@@ -8,6 +8,7 @@ import com.shoprunner.baleen.types.BooleanType
 import com.shoprunner.baleen.types.CoercibleType
 import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.ErrorsAreWarnings
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
@@ -42,6 +43,7 @@ object AvroGenerator {
             is StringType -> Schema.create(Schema.Type.STRING)
             is StringConstantType -> Schema.create(Schema.Type.STRING)
             is EnumType -> Schema.createEnum(baleenType.enumName, null, null, baleenType.enum.toList())
+            is ErrorsAreWarnings<*> -> getAvroSchema(baleenType.type)
             is InstantType -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
             is TimestampMillisType -> LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))
             /* TODO: More Logical Types */

--- a/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroGeneratorTest.kt
+++ b/baleen-avro-generator/src/test/kotlin/com/shoprunner/baleen/avro/AvroGeneratorTest.kt
@@ -10,6 +10,7 @@ import com.shoprunner.baleen.types.AllowsNull
 import com.shoprunner.baleen.types.BooleanType
 import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.ErrorsAreWarnings
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
@@ -88,7 +89,7 @@ class AvroGeneratorTest {
         }
 
         @Test
-        fun `getAvroSchema encodes intger type`() {
+        fun `getAvroSchema encodes integer type`() {
             val schema = AvroGenerator.getAvroSchema(IntegerType())
             assertThat(schema.type).isEqualTo(Schema.Type.LONG)
         }
@@ -197,6 +198,12 @@ class AvroGeneratorTest {
             assertThat(schema.types[0].type).isEqualTo(Schema.Type.NULL)
             assertThat(schema.types[1].type).isEqualTo(Schema.Type.INT)
             assertThat(schema.types[2].type).isEqualTo(Schema.Type.LONG)
+        }
+
+        @Test
+        fun `getAvroSchema encodes ErrorsAreWarnings as string type`() {
+            val schema = AvroGenerator.getAvroSchema(ErrorsAreWarnings(StringType()))
+            assertThat(schema.type).isEqualTo(Schema.Type.STRING)
         }
 
         @Test

--- a/baleen-jsonschema-generator/src/main/kotlin/com/shoprunner/baleen/jsonschema/v3/JsonSchemaGenerator.kt
+++ b/baleen-jsonschema-generator/src/main/kotlin/com/shoprunner/baleen/jsonschema/v3/JsonSchemaGenerator.kt
@@ -19,6 +19,7 @@ import com.shoprunner.baleen.types.BooleanType
 import com.shoprunner.baleen.types.CoercibleType
 import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.ErrorsAreWarnings
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
@@ -125,6 +126,7 @@ object JsonSchemaGenerator : BaseGenerator<JsonSchema, JsonSchemaOptions> {
                     }
                 }
             }
+            is ErrorsAreWarnings<*> -> typeMapper(baleenType.type, options)
         // V3 Does not support
             is AllowsNull<*> -> typeMapper(baleenType.type, options)
             else -> throw Exception("Unknown type: " + baleenType::class.simpleName)

--- a/baleen-jsonschema-generator/src/main/kotlin/com/shoprunner/baleen/jsonschema/v4/JsonSchemaGenerator.kt
+++ b/baleen-jsonschema-generator/src/main/kotlin/com/shoprunner/baleen/jsonschema/v4/JsonSchemaGenerator.kt
@@ -11,6 +11,7 @@ import com.shoprunner.baleen.types.BooleanType
 import com.shoprunner.baleen.types.CoercibleType
 import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.ErrorsAreWarnings
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
@@ -143,6 +144,7 @@ object JsonSchemaGenerator : BaseGenerator<JsonSchema, JsonSchemaOptions> {
                     OneOf(subSchemas)
                 }
             }
+            is ErrorsAreWarnings<*> -> typeMapper(baleenType.type, options)
             else -> throw Exception("No mapping is defined for ${baleenType.name()} to JsonSchema")
         }
     }

--- a/baleen-jsonschema-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v3/JsonSchemaGeneratorTest.kt
+++ b/baleen-jsonschema-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v3/JsonSchemaGeneratorTest.kt
@@ -18,6 +18,7 @@ import com.shoprunner.baleen.types.AllowsNull
 import com.shoprunner.baleen.types.BooleanType
 import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.ErrorsAreWarnings
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
@@ -255,6 +256,14 @@ internal class JsonSchemaGeneratorTest {
             org.junit.jupiter.api.Assertions.assertThrows(Exception::class.java) {
                 JsonSchemaGenerator.getJsonSchema(UnionType(IntType(), dogType))
             }
+        }
+
+        @Test
+        fun `getJsonSchema encodes ErrorsAsWarnings type as string type`() {
+            val schema = JsonSchemaGenerator.getJsonSchema(ErrorsAreWarnings(StringType()))
+            Assertions.assertThat(schema.isStringSchema).isTrue()
+            Assertions.assertThat((schema as StringSchema).minLength).isEqualTo(0)
+            Assertions.assertThat(schema.maxLength).isEqualTo(Int.MAX_VALUE)
         }
 
         @Test

--- a/baleen-jsonschema-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v4/JsonSchemaGeneratorTest.kt
+++ b/baleen-jsonschema-generator/src/test/kotlin/com/shoprunner/baleen/jsonschema/v4/JsonSchemaGeneratorTest.kt
@@ -26,6 +26,7 @@ import com.shoprunner.baleen.types.StringConstantType
 import com.shoprunner.baleen.types.StringType
 import com.shoprunner.baleen.types.TimestampMillisType
 import com.shoprunner.baleen.types.UnionType
+import com.shoprunner.baleen.types.asWarnings
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
@@ -1037,6 +1038,41 @@ internal class JsonSchemaGeneratorTest {
                       "type" : "string",
                       "maxLength" : 2147483647,
                       "minLength" : 0
+                    }
+                  }
+                }
+              },
+              "${'$'}ref" : "#/definitions/record:Dog",
+              "${'$'}schema" : "http://json-schema.org/draft-04/schema"
+            }""".trimIndent()
+
+            val outputStream = ByteArrayOutputStream()
+            JsonSchemaGenerator.encode(description).writeTo(PrintStream(outputStream), true)
+
+            Assertions.assertThat(outputStream.toString()).isEqualToIgnoringWhitespace(schemaStr)
+        }
+
+        @Test
+        fun `getJsonSchema encodes ErrorsAreWarnings as string type`() {
+            val description = Baleen.describe("Dog") {
+                it.attr(
+                    name = "name",
+                    type = StringType(min = 1, max = 10).asWarnings()
+                )
+            }
+
+            val schemaStr = """
+            {
+              "id" : "Dog",
+              "definitions" : {
+                "record:Dog" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "name" : {
+                      "type" : "string",
+                      "maxLength" : 10,
+                      "minLength" : 1
                     }
                   }
                 }

--- a/baleen-kotlin/baleen-kotlin-generator/src/main/kotlin/com/shoprunner/baleen/kotlin/DataClassGenerator.kt
+++ b/baleen-kotlin/baleen-kotlin-generator/src/main/kotlin/com/shoprunner/baleen/kotlin/DataClassGenerator.kt
@@ -10,6 +10,7 @@ import com.shoprunner.baleen.types.BooleanType
 import com.shoprunner.baleen.types.CoercibleType
 import com.shoprunner.baleen.types.DoubleType
 import com.shoprunner.baleen.types.EnumType
+import com.shoprunner.baleen.types.ErrorsAreWarnings
 import com.shoprunner.baleen.types.FloatType
 import com.shoprunner.baleen.types.InstantType
 import com.shoprunner.baleen.types.IntType
@@ -84,6 +85,7 @@ object DataClassGenerator {
                 }
                 CoercibleHandlerOption.TO -> this.type.asTypeName(options)
             }
+            is ErrorsAreWarnings<*> -> this.type.asTypeName(options)
             else -> throw Exception("Unknown type: " + this::class)
         }
     }

--- a/baleen-kotlin/baleen-kotlin-generator/src/test/kotlin/com/shoprunner/baleen/kotlin/DataClassGeneratorForSimpleModelsTest.kt
+++ b/baleen-kotlin/baleen-kotlin-generator/src/test/kotlin/com/shoprunner/baleen/kotlin/DataClassGeneratorForSimpleModelsTest.kt
@@ -17,6 +17,7 @@ import com.shoprunner.baleen.types.StringCoercibleToLong
 import com.shoprunner.baleen.types.StringConstantType
 import com.shoprunner.baleen.types.StringType
 import com.shoprunner.baleen.types.TimestampMillisType
+import com.shoprunner.baleen.types.asWarnings
 import java.io.StringWriter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -840,6 +841,47 @@ internal class DataClassGeneratorForSimpleModelsTest {
                * Test field
                */
               val field: String? = null
+            )
+
+        """.trimIndent()
+
+        val dataClassSpecs = DataClassGenerator.encode(model)
+        val outputStream = StringWriter()
+        dataClassSpecs[model]!!.writeTo(outputStream)
+        val outputStr = outputStream.toString()
+
+        assertThat(dataClassSpecs).hasSize(1)
+        // assertThat(outputStr).isEqualToIgnoringWhitespace(expectedDataClassStr)
+        assertThat(outputStr).isEqualTo(expectedDataClassStr)
+    }
+
+    @Test
+    fun `test ErrorsAreWarnings with StringType`() {
+        val model = "Model".describeAs(
+            nameSpace = "com.shoprunner.baleen.kotlin.test",
+            markdownDescription = "Test Model"
+        ) {
+            "field".type(
+                type = StringType().asWarnings(),
+                markdownDescription = "Test field"
+            )
+        }
+
+        val expectedDataClassStr = """
+            package com.shoprunner.baleen.kotlin.test
+
+            import com.shoprunner.baleen.annotation.DataDescription
+            import kotlin.String
+            
+            /**
+             * Test Model
+             */
+            @DataDescription
+            data class Model(
+              /**
+               * Test field
+               */
+              val field: String
             )
 
         """.trimIndent()

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
@@ -24,9 +24,10 @@ class AttributeDescription(
             }
         }
 
-    fun test(validator: Validator) {
+    fun test(validator: Validator): AttributeDescription {
         // TODO change context
         tests.add(validator)
+        return this
     }
 
     fun describe(block: (AttributeDescription) -> Unit): AttributeDescription {

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
@@ -1,5 +1,7 @@
 package com.shoprunner.baleen
 
+import com.shoprunner.baleen.types.asWarnings
+
 class AttributeDescription(
     val dataDescription: DataDescription,
     val name: String,
@@ -9,12 +11,53 @@ class AttributeDescription(
     val required: Boolean,
     val default: Any?
 ) {
+    private val tests: MutableList<Validator> = mutableListOf()
+    private var warn: Boolean = false
+
+    internal val allTests: List<Validator>
+        get() {
+            val allTests = tests + this::validate
+            return if (warn) {
+                allTests.map { it.asWarnings() }
+            } else {
+                allTests
+            }
+        }
+
     fun test(validator: Validator) {
         // TODO change context
-        dataDescription.test(validator)
+        tests.add(validator)
     }
 
     fun describe(block: (AttributeDescription) -> Unit) {
         block(this)
+    }
+
+    fun asWarnings(): AttributeDescription {
+        warn = true
+        return this
+    }
+
+    private fun validate(dataTrace: DataTrace, data: Data): Sequence<ValidationResult> {
+        return when {
+            data.containsKey(name) -> {
+                val (value, attrDataTrace) = data.attributeDataValue(name, dataTrace)
+                sequenceOf(ValidationInfo(dataTrace, "has attribute \"${name}\"", data)).plus(
+                    type.validate(
+                        attrDataTrace,
+                        value
+                    )
+                )
+            }
+            default != NoDefault -> sequenceOf(
+                ValidationInfo(
+                    dataTrace,
+                    "has attribute \"${name}\" defaulted to `$default` since it wasn't set.",
+                    data
+                )
+            )
+            required -> sequenceOf(ValidationError(dataTrace, "missing required attribute \"${name}\"", data))
+            else -> sequenceOf(ValidationInfo(dataTrace, "missing attribute \"${name}\"", data))
+        }
     }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
@@ -29,8 +29,9 @@ class AttributeDescription(
         tests.add(validator)
     }
 
-    fun describe(block: (AttributeDescription) -> Unit) {
+    fun describe(block: (AttributeDescription) -> Unit): AttributeDescription {
         block(this)
+        return this
     }
 
     fun asWarnings(): AttributeDescription {

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/ErrorsAreWarnings.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/ErrorsAreWarnings.kt
@@ -5,14 +5,36 @@ import com.shoprunner.baleen.DataTrace
 import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.ValidationResult
 import com.shoprunner.baleen.ValidationWarning
+import com.shoprunner.baleen.Validator
 
+/**
+ * Baleen Type wrapper that turns all `ValidationError`s into `ValidationWarning`s
+ */
 class ErrorsAreWarnings<out T : BaleenType>(val type: T) : BaleenType {
-    override fun name() = "null or ${type.name()}"
+    override fun name(): String = type.name()
 
     override fun validate(dataTrace: DataTrace, value: Any?): Sequence<ValidationResult> =
-            type.validate(dataTrace, value).map { when (it) {
-                is ValidationError -> ValidationWarning(it.dataTrace, it.message, it.value)
-                else -> it
-                }
-            }
+            type.validate(dataTrace, value).asWarnings()
+}
+
+/**
+ * Transforms the validation errors into warnings
+ */
+fun <T : BaleenType> T.asWarnings(): ErrorsAreWarnings<T> = ErrorsAreWarnings(this)
+
+/**
+ * Wraps the Validator function with a Validator function that maps errors into warnings.
+ */
+fun Validator.asWarnings(): Validator = { dataTrace, data ->
+    this.invoke(dataTrace, data).asWarnings()
+}
+
+/**
+ * Iterates through the validation results and transforms errors into warnings
+ */
+fun Sequence<ValidationResult>.asWarnings(): Sequence<ValidationResult> = this.map {
+    when (it) {
+        is ValidationError -> ValidationWarning(it.dataTrace, it.message, it.value)
+        else -> it
+    }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/types/ErrorsAreWarnings.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/types/ErrorsAreWarnings.kt
@@ -26,7 +26,7 @@ fun <T : BaleenType> T.asWarnings(): ErrorsAreWarnings<T> = ErrorsAreWarnings(th
  * Wraps the Validator function with a Validator function that maps errors into warnings.
  */
 fun Validator.asWarnings(): Validator = { dataTrace, data ->
-    this.invoke(dataTrace, data).asWarnings()
+    this(dataTrace, data).asWarnings()
 }
 
 /**

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/BaleenTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/BaleenTest.kt
@@ -105,6 +105,32 @@ internal class BaleenTest {
     }
 
     @Nested
+    inner class AttributeAsWarnings {
+
+        private val dogDescription = "Dog".describeAs {
+            "name".type(
+                type = AllowsNull(StringType()),
+                required = true
+            ).asWarnings()
+        }
+
+        @Test
+        fun `passes validation when present`() {
+            val data = dataOf("name" to "Fido")
+            assertThat(dogDescription.validate(data)).isValid()
+            assertThat(dogDescription.validate(data).results).contains(ValidationInfo(dataTrace(), "has attribute \"name\"", data))
+        }
+
+        @Test
+        fun `warns validation when data missing required attribute`() {
+            val data = dataOf<String>()
+            assertThat(dogDescription.validate(data)).isValid()
+            assertThat(dogDescription.validate(data).results).contains(
+                ValidationWarning(dataTrace(), "missing required attribute \"name\"", data))
+        }
+    }
+
+    @Nested
     inner class NestedDesc {
         private val dogDescription = "Dog".describeAs {
             "name".type(

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/types/ErrorsAreWarningsTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/types/ErrorsAreWarningsTest.kt
@@ -1,0 +1,69 @@
+package com.shoprunner.baleen.types
+
+import com.shoprunner.baleen.Data
+import com.shoprunner.baleen.DataTrace
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import com.shoprunner.baleen.ValidationError
+import com.shoprunner.baleen.ValidationInfo
+import com.shoprunner.baleen.ValidationResult
+import com.shoprunner.baleen.ValidationWarning
+import com.shoprunner.baleen.dataTrace
+import com.shoprunner.baleen.datawrappers.HashData
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class ErrorsAreWarningsTest {
+
+    @Test
+    fun `test ErrorsAreWarnings wrap BaleenType`() {
+        val type = ErrorsAreWarnings(StringType())
+        val correctResults = type.validate(dataTrace(), "Correct")
+        assertThat(correctResults).isEmpty()
+
+        val warningResults = type.validate(dataTrace(), 1234)
+        assertThat(warningResults).containsExactly(ValidationWarning(dataTrace(), "is not a string", 1234))
+    }
+
+    @Test
+    fun `test BaleenType#isWarning transforms BaleenType to ErrorsAreWarning`() {
+        val type = StringType().asWarnings()
+        val correctResults = type.validate(dataTrace(), "Correct")
+        assertThat(correctResults).isEmpty()
+
+        val warningResults = type.validate(dataTrace(), 1234)
+        assertThat(warningResults).containsExactly(ValidationWarning(dataTrace(), "is not a string", 1234))
+    }
+
+    @Test
+    fun `test Validator#isWarning returns a function that transforms ValidationErrors to ValidationWarnings`() {
+        fun myKeyCheck(dataTrace: DataTrace, data: Data): Sequence<ValidationResult> =
+            if (!data.containsKey("key")) {
+                sequenceOf(ValidationError(dataTrace, "key not found", data))
+            } else {
+                emptySequence()
+            }
+
+        val myKeyWarning = ::myKeyCheck.asWarnings()
+
+        val correctResults = myKeyWarning(dataTrace(), HashData(mapOf("key" to "value")))
+        assertThat(correctResults).isEmpty()
+
+        val badData = HashData(mapOf("nokey" to "value"))
+        val warningResults = myKeyWarning(dataTrace(), badData)
+        assertThat(warningResults).containsExactly(ValidationWarning(dataTrace(), "key not found", badData))
+    }
+
+    @Test
+    fun `test Sequence#isWarning returns a function that transforms ValidationErrors to ValidationWarnings`() {
+        val results = sequenceOf(
+            ValidationInfo(dataTrace(), "good data", "hello world"),
+            ValidationError(dataTrace(), "bad data", null)
+        )
+        val warningResults = results.asWarnings()
+        assertThat(warningResults).containsExactly(
+            ValidationInfo(dataTrace(), "good data", "hello world"),
+            ValidationWarning(dataTrace(), "bad data", null)
+        )
+    }
+}


### PR DESCRIPTION
Sometimes you will want an attribute or type to warn instead of error. The `asWarnings()` method will transform the output from `ValidationError` to `ValidationWarning` for all nested tests run underneath that attribute/type.


```kotlin
import com.shoprunner.baleen.Baleen.describeAs
import com.shoprunner.baleen.ValidationError
import com.shoprunner.baleen.dataTrace
import com.shoprunner.baleen.types.StringType
import com.shoprunner.baleen.types.asWarnings


val productDescription = "Product".describeAs {

    // The asWarnings() method is on StringType. Min/max are warnings, but required is still an error.
    "sku".type(StringType(min = 1, max = 500).asWarnings(), required = true) 

    // The asWarnings() method is on the attribute. Min/max and required are all warnings.
    "brand_manufacturer".type(StringType(min = 1, max = 500), required = true).asWarnings()

    // The asWarnings() method is on the attribute. The attribute's custom test will also be turned into a warning.
    "department".type(StringType(min = 0, max = 100)).describe { attr ->

        attr.test { datatrace, value ->
            val department = value["department"]
            if (department != null && !departments.contains(department)) {
                sequenceOf(ValidationError(dataTrace, "Department ($department) is not a valid value.", value))
            } else {
                sequenceOf()
            }
        }
    }.asWarnings()
}
```