### PR TITLE
Support JUnit style assertions and test writing in data descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ val productDescription = "Product".describeAs {
 
     "department".type(StringType(min = 0, max = 100))
          .describeAs {
-             test("department is correct value") { data -> 
-                 assertThat(departments).contains(data.getAsString("department").getOrNull())
+             test("department is correct value") { data ->
+                 assertThat(data).hasAttribute("department") {
+                     it.isOneOf(departments)
+                 }
              }
          }
 }
@@ -120,7 +122,9 @@ val productDescription = "Product".describeAs {
     // The asWarnings() method is on the attribute. The attribute's custom test will also be turned into a warning.
     "department".type(StringType(min = 0, max = 100)).describeAs {
         test("department is correct value") { data ->
-            assertThat(departments).contains(data.getAsString("department").getOrNull())
+            assertThat(data).hasAttribute("department") {
+                it.isOneOf(departments)
+            }
         }
     }.asWarnings()
 }
@@ -170,7 +174,9 @@ Tagging is also done at the data evaluation level.  When writing tests, addition
 ```kotlin
     "department".type(StringType(min = 0, max = 100)).describeAs {
         test("department is correct value", "sku" to withAttributeValue("sku")) { data ->
-            assertThat(departments).contains(data.getAsString("department").getOrNull())
+            assertThat(data).hasAttribute("department") {
+                it.isOneOf(departments)
+            }
         }
     }
 ```

--- a/README.md
+++ b/README.md
@@ -36,17 +36,11 @@ val productDescription = "Product".describeAs {
           required = true)
 
     "department".type(StringType(min = 0, max = 100))
-         .describe { attr ->
-
-        attr.test { datatrace, value ->
-            val department = value["department"]
-            if (department != null && !departments.contains(department)) {
-                sequenceOf(ValidationError(dataTrace, "Department ($department) is not a valid value.", value))
-            } else {
-                sequenceOf()
-            }
-        }
-    }
+         .describeAs {
+             test("department is correct value") { data -> 
+                 assertThat(departments).contains(data.getAsString("department").getOrNull())
+             }
+         }
 }
 ```
 
@@ -76,7 +70,7 @@ Join the [slack channel](https://join.slack.com/t/baleen-validation/signup)
 
 - Don't map data to Types too early.
 
-  Type safe code is great but if the data hasn't been santized then it isn't really typed.  
+  Type safe code is great but if the data hasn't been sanitized then it isn't really typed.  
 
 ### Warnings
 
@@ -100,15 +94,9 @@ val productDescription = "Product".describeAs {
     "brand_manufacturer".type(StringType(min = 1, max = 500), required = true).asWarnings()
 
     // The asWarnings() method is on the attribute. The attribute's custom test will also be turned into a warning.
-    "department".type(StringType(min = 0, max = 100)).describe { attr ->
-
-        attr.test { datatrace, value ->
-            val department = value["department"]
-            if (department != null && !departments.contains(department)) {
-                sequenceOf(ValidationError(dataTrace, "Department ($department) is not a valid value.", value))
-            } else {
-                sequenceOf()
-            }
+    "department".type(StringType(min = 0, max = 100)).describeAs {
+        test("department is correct value") { data ->
+            assertThat(departments).contains(data.getAsString("department").getOrNull())
         }
     }.asWarnings()
 }
@@ -154,26 +142,14 @@ val productDescription = "Product".describeAs {
 .tag("sku", withAttributeValue("sku"))
 ``` 
 
-Tagging is also done at the data evaluation level.  When writing tests, DataTrace can be updated with tags
+Tagging is also done at the data evaluation level.  When writing tests, additional tags can be passed in using the Tagger function.
 ```kotlin
-    "department".type(StringType(min = 0, max = 100)).describe { attr ->
-        attr.test { datatrace, value ->
-            val department = value["department"]
-            if (department != null && !departments.contains(department)) {
-
-                // datatrace has the sku tag added
-                sequenceOf(ValidationError(
-                    dataTrace.tag("sku", value["sku"] ?: "null"), 
-                    "Department ($department) is not a valid value.",
-                     value
-                ))
-
-            } else {
-                sequenceOf()
-            }
+    "department".type(StringType(min = 0, max = 100)).describeAs {
+        test("department is correct value", "sku" to withAttributeValue("sku")) { data ->
+            assertThat(departments).contains(data.getAsString("department").getOrNull())
         }
     }
-``` 
+```
 
 Some Baleen Validation libraries, such as the XML or JSON validators, use tags to add line and column numbers as it 
 parses the original raw data. This will help identify errors in the raw data much more quickly.    

--- a/baleen-kotlin/README.md
+++ b/baleen-kotlin/README.md
@@ -69,23 +69,12 @@ Annotation on a top-level method to add additional tests.
 ```kotlin
 package com.shoprunner.baleen.kotlin.example
 
-import com.shoprunner.baleen.DataTrace
-import com.shoprunner.baleen.ValidationError
-import com.shoprunner.baleen.ValidationInfo
-import com.shoprunner.baleen.ValidationResult
+import com.shoprunner.baleen.Assertions
 import com.shoprunner.baleen.annotation.DataTest
-import com.shoprunner.baleen.dataTrace
 
 @DataTest
-fun assert3orMoreLegs(dog: Dog, dataTrace: DataTrace = dataTrace()): Sequence<ValidationResult> {
-    val numLegs = dog.numLegs
-    if(numLegs == null) {
-        return emptySequence()
-    } else if (numLegs >= 3) {
-        return sequenceOf(ValidationInfo(dataTrace, "Num Legs greater or equal to 3", numLegs))
-    } else {
-        return sequenceOf(ValidationError(dataTrace, "Num Legs less than 3", numLegs))
-    }
+fun test3orMoreLegs(assertions: Assertions, dog: Dog) = with(assertions) {
+    assertThat(dog.numLegs).isGreaterThanEquals(3)
 }
 ```
 

--- a/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataTestElement.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/DataTestElement.kt
@@ -4,7 +4,8 @@ import javax.lang.model.element.ExecutableElement
 import javax.lang.model.type.DeclaredType
 
 data class DataTestElement(
-    val executableElement: ExecutableElement,
-    val receiverType: DeclaredType,
-    val isExtension: Boolean
+    val dataTestFunction: ExecutableElement,
+    val dataClass: DeclaredType,
+    val isExtension: Boolean,
+    val isAssertionBased: Boolean
 )

--- a/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/MessagerHelpers.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/main/kotlin/com/shoprunner/baleen/kapt/MessagerHelpers.kt
@@ -3,13 +3,13 @@ package com.shoprunner.baleen.kapt
 import javax.annotation.processing.Messager
 
 fun Messager.error(message: () -> String) {
-    this.printMessage(javax.tools.Diagnostic.Kind.ERROR, message())
+    this.printMessage(javax.tools.Diagnostic.Kind.ERROR, "${message()}\r\n")
 }
 
 fun Messager.note(message: () -> String) {
-    this.printMessage(javax.tools.Diagnostic.Kind.NOTE, message())
+    this.printMessage(javax.tools.Diagnostic.Kind.NOTE, "${message()}\r\n")
 }
 
 fun Messager.warning(message: () -> String) {
-    this.printMessage(javax.tools.Diagnostic.Kind.WARNING, message())
+    this.printMessage(javax.tools.Diagnostic.Kind.WARNING, "${message()}\r\n")
 }

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/BasicModelTest.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/BasicModelTest.kt
@@ -16,6 +16,7 @@ import com.shoprunner.baleen.types.StringType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.time.Duration
 import java.time.Instant
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -153,7 +154,7 @@ internal class BasicModelTest {
 
     @Test
     fun `test data class with instants produce valid data descriptions`() {
-        val model = InstantModel(Instant.now(), null)
+        val model = InstantModel(Instant.now().plus(Duration.ofDays(1)), null)
 
         assertBaleen(model.dataDescription())
             .hasName("InstantModel")

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/DataTestFunctions.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/DataTestFunctions.kt
@@ -1,11 +1,13 @@
 package com.shoprunner.baleen.kotlin.kapt.test
 
+import com.shoprunner.baleen.Assertions
 import com.shoprunner.baleen.DataTrace
 import com.shoprunner.baleen.ValidationError
 import com.shoprunner.baleen.ValidationInfo
 import com.shoprunner.baleen.ValidationResult
 import com.shoprunner.baleen.annotation.DataTest
 import com.shoprunner.baleen.dataTrace
+import java.time.Instant
 
 @DataTest
 fun assertStringLength(stringModel: StringModel, dataTrace: DataTrace = dataTrace()): Sequence<ValidationResult> {
@@ -41,4 +43,14 @@ fun assertArrayNotEmpty(arrayModel: ArrayStringModel, dataTrace: DataTrace = dat
     } else {
         return listOf(ValidationError(dataTrace + "attr stringArray", "is empty", arrayModel.stringArray))
     }
+}
+
+@DataTest
+fun testInstantAfterToday(assertions: Assertions, instantModel: InstantModel) = with(assertions) {
+    assertTrue("instant >= today", instantModel.instant.isAfter(Instant.now()))
+}
+
+@DataTest(isExtension = true)
+fun Assertions.testMaxIs100(intModel: LongModel) {
+    assertThat(intModel.longNumber).isLessThanEquals(100)
 }

--- a/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/DataTestFunctionsGenerationTest.kt
+++ b/baleen-kotlin/baleen-kotlin-kapt/src/test/kotlin/com/shoprunner/baleen/kotlin/kapt/test/DataTestFunctionsGenerationTest.kt
@@ -4,6 +4,8 @@ import com.shoprunner.baleen.kotlin.validate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+import java.time.Instant
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class DataTestFunctionsGenerationTest {
@@ -39,6 +41,24 @@ internal class DataTestFunctionsGenerationTest {
     fun `tests 'assertArrayNotEmpty' a @DataTest with Iterable return value validates correctly`() {
         val goodData = ArrayStringModel(arrayOf("string"), null)
         val badData = ArrayStringModel(emptyArray(), null)
+
+        assertThat(goodData.validate().isValid()).isTrue()
+        assertThat(badData.validate().isValid()).isFalse()
+    }
+
+    @Test
+    fun `tests 'test instant after today' a @DataTest with Assertions as parameter`() {
+        val goodData = InstantModel(Instant.now().plus(Duration.ofDays(1)), null)
+        val badData = InstantModel(Instant.now().minus(Duration.ofDays(1)), null)
+
+        assertThat(goodData.validate().isValid()).isTrue()
+        assertThat(badData.validate().isValid()).isFalse()
+    }
+
+    @Test
+    fun `tests 'test max is 100' a @DataTest as an Assertion extension validates correctly`() {
+        val goodData = LongModel(1, null)
+        val badData = LongModel(1000, null)
 
         assertThat(goodData.validate().isValid()).isTrue()
         assertThat(badData.validate().isValid()).isFalse()

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/AssertThat.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/AssertThat.kt
@@ -1,0 +1,18 @@
+package com.shoprunner.baleen
+
+/**
+ * Container around the value. It can be the correct typed value OR
+ * the incorrect type for errors. The `actual` value is kept for
+ * reporting purposes.
+ */
+sealed class AssertThat<T>(val actual: Any?, val messagePrefix: String)
+
+/**
+ * The value is the correct type and can be asserted on. The typed value is accessible.
+ */
+class AssertThatValue<T>(val typedActual: T, messagePrefix: String = "") : AssertThat<T>(typedActual, messagePrefix)
+
+/**
+ * The value is incorrect type and cannot be asserted on. The actual value is available for reviewing.
+ */
+class AssertThatNoValue<T>(actual: Any?, messagePrefix: String = "") : AssertThat<T>(actual, messagePrefix)

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -67,8 +67,10 @@ class Assertions(val dataTrace: DataTrace) {
     inline fun <reified T> assertThat(messagePrefix: String = "", getFun: () -> MaybeData<*, T>): AssertThat<T> {
         return when (val result = getFun()) {
             is BadData -> {
-                fail("assertThat<${T::class.qualifiedName}>(${messagePrefix.trim()})",
-                    "${result.original} is a ${result.original?.let { it::class.qualifiedName } ?: "${T::class.qualifiedName}?"}")
+                fail(
+                    "assertThat<${T::class.qualifiedName}>(${messagePrefix.trim()})",
+                    "${result.original} is a ${result.original?.let { it::class.qualifiedName } ?: "${T::class.qualifiedName}?"}"
+                )
                 AssertThatNoValue(result.original, messagePrefix)
             }
             is GoodData -> {

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -39,15 +39,12 @@ class Assertions(val dataTrace: DataTrace) {
     }
 
     /**
-     * Begin assertions for a single value
-     * @param actual the value we are testing
+     * Begin assertions for a data map
+     * @param actual the data we are testing
      * @param messagePrefix an optional prefix to make the data more informative
      */
-    @ExperimentalContracts
-    inline fun <reified T> assertThat(data: Data, key: String, messagePrefix: String = "data[$key] "): AssertThat<T> {
-        return assertThat(messagePrefix) {
-            data.getAs(key)
-        }
+    fun assertThat(actual: Data, messagePrefix: String = ""): AssertThat<Data> {
+        return AssertThatValue(actual, messagePrefix)
     }
 
     /**
@@ -77,6 +74,24 @@ class Assertions(val dataTrace: DataTrace) {
         }
     }
 
+    fun AssertThat<Data>.hasAttribute(attribute: String, attributeAssertions: Assertions.(AssertThat<Any?>)-> Unit = {}): AssertThat<Data> {
+        when(this) {
+            is AssertThatValue<Data> ->
+                if (this.typedActual.containsKey(attribute)) {
+                    pass(messagePrefix + "data[$attribute] exists", this.typedActual)
+                    attributeAssertions(assertThat(this.typedActual[attribute], messagePrefix + "data[$attribute] "))
+                } else {
+                    fail(messagePrefix + "data[$attribute] exists", this.typedActual)
+                    attributeAssertions(AssertThatNoValue(null, messagePrefix + "data[$attribute] "))
+                }
+            is AssertThatNoValue -> {
+                fail(messagePrefix + "data[$attribute] exists", this.actual)
+                attributeAssertions(AssertThatNoValue(null, messagePrefix + "data[$attribute] "))
+            }
+        }
+        return this
+    }
+
     fun assertTrue(message: String, test: Boolean?, value: Any? = null): Boolean {
         return if (test != null && test) {
             pass(message, value)
@@ -87,7 +102,7 @@ class Assertions(val dataTrace: DataTrace) {
         }
     }
 
-    fun <T : Boolean?> AssertThat<T>.isTrue(message: String = "is true"): AssertThat<T> {
+    fun AssertThat<Boolean>.isTrue(message: String = "is true"): AssertThat<Boolean> {
         when (this) {
             is AssertThatValue ->
                 assertTrue(this.messagePrefix + message, this.typedActual, this.actual)
@@ -101,7 +116,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, test?.not(), right)
     }
 
-    fun <T : Boolean?> AssertThat<T>.isFalse(message: String = "is false"): AssertThat<T> {
+    fun AssertThat<Boolean>.isFalse(message: String = "is false"): AssertThat<Boolean> {
         when (this) {
             is AssertThatValue ->
                 assertFalse(this.messagePrefix + message, this.typedActual, this.actual)
@@ -143,7 +158,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
     }
 
-    fun <T : Int?> AssertThat<T>.isLessThan(expected: Int, message: String = "is less than $expected"): AssertThat<T> {
+    fun AssertThat<Int>.isLessThan(expected: Int, message: String = "is less than $expected"): AssertThat<Int> {
         when (this) {
             is AssertThatValue ->
                 assertLessThan(this.messagePrefix + message, this.typedActual, expected)
@@ -157,7 +172,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
     }
 
-    fun <T : Long?> AssertThat<T>.isLessThan(expected: Long, message: String = "is less than $expected"): AssertThat<T> {
+    fun AssertThat<Long>.isLessThan(expected: Long, message: String = "is less than $expected"): AssertThat<Long> {
         when (this) {
             is AssertThatValue ->
                 assertLessThan(this.messagePrefix + message, this.typedActual, expected)
@@ -171,7 +186,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
     }
 
-    fun <T : Float?> AssertThat<T>.isLessThan(expected: Float, message: String = "is less than $expected"): AssertThat<T> {
+    fun AssertThat<Float>.isLessThan(expected: Float, message: String = "is less than $expected"): AssertThat<Float> {
         when (this) {
             is AssertThatValue ->
                 assertLessThan(this.messagePrefix + message, this.typedActual, expected)
@@ -185,7 +200,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
     }
 
-    fun <T : Double?> AssertThat<T>.isLessThan(expected: Double, message: String = "is less than $expected"): AssertThat<T> {
+    fun AssertThat<Double>.isLessThan(expected: Double, message: String = "is less than $expected"): AssertThat<Double> {
         when (this) {
             is AssertThatValue ->
                 assertLessThan(this.messagePrefix + message, this.typedActual, expected)
@@ -199,7 +214,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
-    fun <T : Int?> AssertThat<T>.isLessThanEquals(expected: Int, message: String = "is less than equals $expected"): AssertThat<T> {
+    fun AssertThat<Int>.isLessThanEquals(expected: Int, message: String = "is less than equals $expected"): AssertThat<Int> {
         when (this) {
             is AssertThatValue ->
                 assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
@@ -213,7 +228,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
-    fun <T : Long?> AssertThat<T>.isLessThanEquals(expected: Long, message: String = "is less than equals $expected"): AssertThat<T> {
+    fun AssertThat<Long>.isLessThanEquals(expected: Long, message: String = "is less than equals $expected"): AssertThat<Long> {
         when (this) {
             is AssertThatValue ->
                 assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
@@ -227,7 +242,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
-    fun <T : Float?> AssertThat<T>.isLessThanEquals(expected: Float, message: String = "is less than equals $expected"): AssertThat<T> {
+    fun AssertThat<Float>.isLessThanEquals(expected: Float, message: String = "is less than equals $expected"): AssertThat<Float> {
         when (this) {
             is AssertThatValue ->
                 assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
@@ -241,7 +256,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
-    fun <T : Double?> AssertThat<T>.isLessThanEquals(expected: Double, message: String = "is less than equals $expected"): AssertThat<T> {
+    fun AssertThat<Double>.isLessThanEquals(expected: Double, message: String = "is less than equals $expected"): AssertThat<Double> {
         when (this) {
             is AssertThatValue ->
                 assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
@@ -255,7 +270,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
-    fun <T : Int?> AssertThat<T>.isGreaterThan(expected: Int, message: String = "is greater than $expected"): AssertThat<T> {
+    fun AssertThat<Int>.isGreaterThan(expected: Int, message: String = "is greater than $expected"): AssertThat<Int> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
@@ -269,7 +284,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
-    fun <T : Long?> AssertThat<T>.isGreaterThan(expected: Long, message: String = "is greater than $expected"): AssertThat<T> {
+    fun AssertThat<Long>.isGreaterThan(expected: Long, message: String = "is greater than $expected"): AssertThat<Long> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
@@ -283,7 +298,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
-    fun <T : Float?> AssertThat<T>.isGreaterThan(expected: Float, message: String = "is greater than $expected"): AssertThat<T> {
+    fun AssertThat<Float>.isGreaterThan(expected: Float, message: String = "is greater than $expected"): AssertThat<Float> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
@@ -297,7 +312,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
-    fun <T : Double?> AssertThat<T>.isGreaterThan(expected: Double, message: String = "is greater than $expected"): AssertThat<T> {
+    fun AssertThat<Double>.isGreaterThan(expected: Double, message: String = "is greater than $expected"): AssertThat<Double> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
@@ -311,7 +326,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
-    fun <T : Int?> AssertThat<T>.isGreaterThanEquals(expected: Int, message: String = "is greater than equals $expected"): AssertThat<T> {
+    fun AssertThat<Int>.isGreaterThanEquals(expected: Int, message: String = "is greater than equals $expected"): AssertThat<Int> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
@@ -325,7 +340,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
-    fun <T : Long?> AssertThat<T>.isGreaterThanEquals(expected: Long, message: String = "is greater than equals $expected"): AssertThat<T> {
+    fun AssertThat<Long>.isGreaterThanEquals(expected: Long, message: String = "is greater than equals $expected"): AssertThat<Long> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
@@ -339,7 +354,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
-    fun <T : Float?> AssertThat<T>.isGreaterThanEquals(expected: Float, message: String = "is greater than equals $expected"): AssertThat<T> {
+    fun AssertThat<Float>.isGreaterThanEquals(expected: Float, message: String = "is greater than equals $expected"): AssertThat<Float> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
@@ -353,7 +368,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
-    fun <T : Double?> AssertThat<T>.isGreaterThanEquals(expected: Double, message: String = "is greater than equals $expected"): AssertThat<T> {
+    fun AssertThat<Double>.isGreaterThanEquals(expected: Double, message: String = "is greater than equals $expected"): AssertThat<Double> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
@@ -367,7 +382,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.contains(value) == true, "$value in $collection")
     }
 
-    fun <T, C : Collection<T>?> AssertThat<C>.contains(expected: T, message: String = "contains $expected"): AssertThat<C> {
+    fun <T, C: Collection<T>> AssertThat<C>.contains(expected: T, message: String = "contains $expected"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertContains(this.messagePrefix + message, this.typedActual, expected)
@@ -377,11 +392,21 @@ class Assertions(val dataTrace: DataTrace) {
         return this
     }
 
+    fun <T: Any?> AssertThat<T>.isOneOf(collection: Collection<T>, message: String = "is one of $collection"): AssertThat<T> {
+        when(this) {
+            is AssertThatValue ->
+                assertContains(this.messagePrefix + message, collection, this.typedActual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, "${this.actual} in $collection")
+        }
+        return this
+    }
+
     fun assertNotContains(message: String, collection: Collection<*>?, value: Any?) {
         assertTrue(message, collection?.contains(value) == false, "$value not in $collection")
     }
 
-    fun <T, C : Collection<T>?> AssertThat<C>.notContains(expected: T, message: String = "not contains $expected"): AssertThat<C> {
+    fun <T, C: Collection<T>> AssertThat<C>.notContains(expected: T, message: String = "not contains $expected"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertNotContains(this.messagePrefix + message, this.typedActual, expected)
@@ -395,7 +420,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.isEmpty() == true, collection)
     }
 
-    fun <T : Collection<*>?> AssertThat<T>.isEmpty(message: String = "is empty"): AssertThat<T> {
+    fun <T, C: Collection<T>> AssertThat<C>.isEmpty(message: String = "is empty"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertEmpty(this.messagePrefix + message, this.typedActual)
@@ -409,7 +434,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection.isNullOrEmpty(), collection)
     }
 
-    fun <T : Collection<*>?> AssertThat<T>.isNullOrEmpty(message: String = "is null or empty"): AssertThat<T> {
+    fun <T, C: Collection<T>> AssertThat<C?>.isNullOrEmpty(message: String = "is null or empty"): AssertThat<C?> {
         when (this) {
             is AssertThatValue ->
                 assertNullOrEmpty(this.messagePrefix + message, this.typedActual)
@@ -423,7 +448,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.isNotEmpty() == true, collection)
     }
 
-    fun <T : Collection<*>?> AssertThat<T>.isNotEmpty(message: String = "is not empty"): AssertThat<T> {
+    fun <T, C: Collection<T>?> AssertThat<C>.isNotEmpty(message: String = "is not empty"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertNotEmpty(this.messagePrefix + message, this.typedActual)
@@ -437,7 +462,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.size == size, "$size = size($collection)")
     }
 
-    fun <T : Collection<*>?> AssertThat<T>.isSizeEquals(size: Int, message: String = "is size equal to $size"): AssertThat<T> {
+    fun <T, C: Collection<T>?> AssertThat<C>.isSizeEquals(size: Int, message: String = "is size equal to $size"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertSizeEquals(this.messagePrefix + message, this.typedActual, size)
@@ -456,10 +481,24 @@ class Assertions(val dataTrace: DataTrace) {
     }
 
     @ExperimentalContracts
-    fun <T : Any?> AssertThat<T>.isNull(message: String = "is null"): AssertThat<T> {
+    fun <T> AssertThat<T?>.isNull(message: String = "is null"): AssertThat<Unit> {
         when (this) {
             is AssertThatValue ->
                 assertNull(this.messagePrefix + message, this.typedActual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return AssertThatNoValue(this.actual, messagePrefix)
+    }
+
+    fun <T> AssertThat<T?>.isNullOr(message: String = "is null", body: Assertions.(AssertThat<T>) -> Unit): AssertThat<T?> {
+        when (this) {
+            is AssertThatValue -> {
+                when(typedActual) {
+                    null -> pass(messagePrefix + message, typedActual)
+                    else -> body(AssertThatValue(typedActual, messagePrefix))
+                }
+            }
             is AssertThatNoValue ->
                 fail(this.messagePrefix + message, this.actual)
         }
@@ -475,14 +514,19 @@ class Assertions(val dataTrace: DataTrace) {
     }
 
     @ExperimentalContracts
-    fun <T : Any?> AssertThat<T>.isNotNull(message: String = "is not null"): AssertThat<T> {
-        when (this) {
+    fun <T> AssertThat<T?>.isNotNull(message: String = "is not null"): AssertThat<T> {
+        return when (this) {
             is AssertThatValue ->
-                assertNotNull(this.messagePrefix + message, this.typedActual)
-            is AssertThatNoValue ->
+                if(assertNotNull(this.messagePrefix + message, this.typedActual)) {
+                    AssertThatValue(this.typedActual, this.messagePrefix)
+                } else {
+                    AssertThatNoValue(this.typedActual, this.messagePrefix)
+                }
+            is AssertThatNoValue -> {
                 fail(this.messagePrefix + message, this.actual)
+                AssertThatNoValue(this.actual, this.messagePrefix)
+            }
         }
-        return this
     }
 
     @ExperimentalContracts
@@ -491,5 +535,40 @@ class Assertions(val dataTrace: DataTrace) {
             returns(true) implies (value is T)
         }
         return assertTrue(message, value is T, "$value is a ${value?.let { it::class.qualifiedName } ?: "${T::class.qualifiedName}?"}")
+    }
+
+    inline fun <reified T : Any?> AssertThat<Any?>.isA(message: String = "is a ${T::class.qualifiedName}"): AssertThat<T> {
+        return when (this) {
+            is AssertThatValue ->
+                if(this.typedActual is T) {
+                    pass(messagePrefix + message, this.typedActual)
+                    AssertThatValue(this.typedActual, this.messagePrefix)
+                } else {
+                    fail(messagePrefix + message, this.typedActual)
+                    AssertThatNoValue(this.typedActual, this.messagePrefix)
+                }
+            is AssertThatNoValue -> {
+                fail(this.messagePrefix + message, this.actual)
+                AssertThatNoValue(this.actual, this.messagePrefix)
+            }
+        }
+    }
+
+    /**
+     *
+     */
+    fun <T: Any?> AssertThat<T>.or(vararg ors: Assertions.(AssertThat<T>) -> Unit): AssertThat<T> {
+        val testResults = ors.map { orFun ->
+            val orAssertions = Assertions(dataTrace)
+            orAssertions.orFun(this)
+            orAssertions.results.toList()
+        }
+
+        val firstSuccessOrAllErrors = testResults.firstOrNull { r -> r.none { it is ValidationError } }
+            ?: testResults.flatten()
+
+        firstSuccessOrAllErrors.forEach(this@Assertions::addValidationResult)
+
+        return this
     }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -128,7 +128,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} == $expected")
         }
         return this
     }
@@ -142,7 +142,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertNotEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} != $expected")
         }
         return this
     }
@@ -156,7 +156,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertLessThan(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} < $expected")
         }
         return this
     }
@@ -170,7 +170,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertLessThan(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} < $expected")
         }
         return this
     }
@@ -184,7 +184,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertLessThan(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} < $expected")
         }
         return this
     }
@@ -198,7 +198,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertLessThan(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} < $expected")
         }
         return this
     }
@@ -212,7 +212,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} <= $expected")
         }
         return this
     }
@@ -226,7 +226,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} <= $expected")
         }
         return this
     }
@@ -240,7 +240,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} <= $expected")
         }
         return this
     }
@@ -254,7 +254,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} <= $expected")
         }
         return this
     }
@@ -268,7 +268,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} > $expected")
         }
         return this
     }
@@ -277,12 +277,12 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
-    fun <T : Long?> AssertThat<T>.isGreaterThan(expected: Long, message: String = "is greater than equals $expected"): AssertThat<T> {
+    fun <T : Long?> AssertThat<T>.isGreaterThan(expected: Long, message: String = "is greater than $expected"): AssertThat<T> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} > $expected")
         }
         return this
     }
@@ -291,12 +291,12 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
-    fun <T : Float?> AssertThat<T>.isGreaterThan(expected: Float, message: String = "is greater than equals $expected"): AssertThat<T> {
+    fun <T : Float?> AssertThat<T>.isGreaterThan(expected: Float, message: String = "is greater than $expected"): AssertThat<T> {
         when (this) {
             is AssertThatValue ->
                 assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} > $expected")
         }
         return this
     }
@@ -310,7 +310,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} > $expected")
         }
         return this
     }
@@ -324,7 +324,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} >= $expected")
         }
         return this
     }
@@ -338,7 +338,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} >= $expected")
         }
         return this
     }
@@ -352,7 +352,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} >= $expected")
         }
         return this
     }
@@ -366,7 +366,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "${this.actual} >= $expected")
         }
         return this
     }
@@ -380,7 +380,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertContains(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "$expected in ${this.actual}")
         }
         return this
     }
@@ -394,7 +394,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertNotContains(this.messagePrefix + message, this.typedActual, expected)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "$expected not in ${this.actual}")
         }
         return this
     }
@@ -450,7 +450,7 @@ class Assertions(val dataTrace: DataTrace) {
             is AssertThatValue ->
                 assertSizeEquals(this.messagePrefix + message, this.typedActual, size)
             is AssertThatNoValue ->
-                fail(this.messagePrefix + message, this.actual)
+                fail(this.messagePrefix + message, "$size = size(${this.actual})")
         }
         return this
     }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -5,14 +5,6 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
 /**
- * Container around the value
- */
-sealed class AssertThat<T>(val actual: Any?, val messagePrefix: String)
-
-class AssertThatValue<T>(val typedActual: T, messagePrefix: String = "") : AssertThat<T>(typedActual, messagePrefix)
-class AssertThatNoValue<T>(actual: Any?, messagePrefix: String = "") : AssertThat<T>(actual, messagePrefix)
-
-/**
  * Simplify writing tests by using JUnit style assertions.
  * @param dataTrace The dataTrace for the test
  */

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -3,7 +3,7 @@ package com.shoprunner.baleen
 /**
  * Simplify writing tests by using JUnit style assertions.
  */
-class Asserts(val dataTrace: DataTrace) {
+class Assertions(val dataTrace: DataTrace) {
     private var validationResults: Sequence<ValidationResult> = sequenceOf()
 
     val results: Sequence<ValidationResult> get() = validationResults
@@ -19,7 +19,7 @@ class Asserts(val dataTrace: DataTrace) {
         )
     }
 
-    fun assertFalse(message: String, test: Boolean?, right: Any?) {
+    fun assertFalse(message: String, test: Boolean?, right: Any? = null) {
         assertTrue(message, test?.not(), right)
     }
 
@@ -47,52 +47,52 @@ class Asserts(val dataTrace: DataTrace) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
     }
 
-    fun assertLessThanEqual(message: String, left: Int?, right: Int?) {
-        assertTrue(message, left != null && right != null && left <= right, "$left < $right")
+    fun assertLessThanEquals(message: String, left: Int?, right: Int?) {
+        assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
-    fun assertLessThanEqual(message: String, left: Long?, right: Long?) {
-        assertTrue(message, left != null && right != null && left <= right, "$left < $right")
+    fun assertLessThanEquals(message: String, left: Long?, right: Long?) {
+        assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
-    fun assertLessThanEqual(message: String, left: Float?, right: Float?) {
-        assertTrue(message, left != null && right != null && left <= right, "$left < $right")
+    fun assertLessThanEquals(message: String, left: Float?, right: Float?) {
+        assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
-    fun assertLessThanEqual(message: String, left: Double?, right: Double?) {
-        assertTrue(message, left != null && right != null && left <= right, "$left < $right")
+    fun assertLessThanEquals(message: String, left: Double?, right: Double?) {
+        assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
     fun assertGreaterThan(message: String, left: Int?, right: Int?) {
-        assertTrue(message, left != null && right != null && left > right, "$left < $right")
+        assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
     fun assertGreaterThan(message: String, left: Long?, right: Long?) {
-        assertTrue(message, left != null && right != null && left > right, "$left < $right")
+        assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
     fun assertGreaterThan(message: String, left: Float?, right: Float?) {
-        assertTrue(message, left != null && right != null && left > right, "$left < $right")
+        assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
     fun assertGreaterThan(message: String, left: Double?, right: Double?) {
-        assertTrue(message, left != null && right != null && left > right, "$left < $right")
+        assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
-    fun assertGreaterThanEqual(message: String, left: Int?, right: Int?) {
-        assertTrue(message, left != null && right != null && left >= right, "$left < $right")
+    fun assertGreaterThanEquals(message: String, left: Int?, right: Int?) {
+        assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
-    fun assertGreaterThanEqual(message: String, left: Long?, right: Long?) {
-        assertTrue(message, left != null && right != null && left >= right, "$left < $right")
+    fun assertGreaterThanEquals(message: String, left: Long?, right: Long?) {
+        assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
-    fun assertGreaterThanEqual(message: String, left: Float?, right: Float?) {
-        assertTrue(message, left != null && right != null && left >= right, "$left < $right")
+    fun assertGreaterThanEquals(message: String, left: Float?, right: Float?) {
+        assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
-    fun assertGreaterThanEqual(message: String, left: Double?, right: Double?) {
-        assertTrue(message, left != null && right != null && left >= right, "$left < $right")
+    fun assertGreaterThanEquals(message: String, left: Double?, right: Double?) {
+        assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
     fun assertContains(message: String, collection: Collection<*>?, value: Any?) {
@@ -103,16 +103,20 @@ class Asserts(val dataTrace: DataTrace) {
         assertTrue(message, collection?.contains(value) == false, "$value not in $collection")
     }
 
-    fun assertIsEmpty(message: String, collection: Collection<*>?) {
+    fun assertEmpty(message: String, collection: Collection<*>?) {
         assertTrue(message, collection?.isEmpty() == true, collection)
     }
 
-    fun assertIsNotEmpty(message: String, collection: Collection<*>?) {
+    fun assertNullOrEmpty(message: String, collection: Collection<*>?) {
+        assertTrue(message, collection.isNullOrEmpty(), collection)
+    }
+
+    fun assertNotEmpty(message: String, collection: Collection<*>?) {
         assertTrue(message, collection?.isNotEmpty() == true, collection)
     }
 
-    fun assertSizeEquals(message: String, collection: Collection<*>, size: Int) {
-        assertTrue(message, collection.size == size, "$size = size($collection)")
+    fun assertSizeEquals(message: String, collection: Collection<*>?, size: Int) {
+        assertTrue(message, collection?.size == size, "$size = size($collection)")
     }
 
     fun assertNull(message: String, value: Any?) {

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -1,7 +1,20 @@
 package com.shoprunner.baleen
 
+import com.shoprunner.baleen.Data.Companion.getAs
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Container around the value
+ */
+sealed class AssertThat<T>(val actual: Any?, val messagePrefix: String)
+
+class AssertThatValue<T>(val typedActual: T, messagePrefix: String = "") : AssertThat<T>(typedActual, messagePrefix)
+class AssertThatNoValue<T>(actual: Any?, messagePrefix: String = "") : AssertThat<T>(actual, messagePrefix)
+
 /**
  * Simplify writing tests by using JUnit style assertions.
+ * @param dataTrace The dataTrace for the test
  */
 class Assertions(val dataTrace: DataTrace) {
     private var validationResults: Sequence<ValidationResult> = sequenceOf()
@@ -12,118 +25,477 @@ class Assertions(val dataTrace: DataTrace) {
         validationResults += result
     }
 
-    fun assertTrue(message: String, test: Boolean?, value: Any? = null) {
+    fun pass(message: String, value: Any?) {
         addValidationResult(
-            if (test != null && test) ValidationInfo(dataTrace.tag("assertion" to message), "Pass: $message", value)
-            else ValidationError(dataTrace.tag("assertion" to message), "Fail: $message", value)
+            ValidationInfo(dataTrace.tag("assertion" to message), "Pass: $message", value)
         )
+    }
+
+    fun fail(message: String, value: Any?) {
+        addValidationResult(
+            ValidationError(dataTrace.tag("assertion" to message), "Fail: $message", value)
+        )
+    }
+
+    /**
+     * Begin assertions for a single value
+     * @param actual the value we are testing
+     * @param messagePrefix an optional prefix to make the data more informative
+     */
+    fun <T> assertThat(actual: T, messagePrefix: String = ""): AssertThat<T> {
+        return AssertThatValue(actual, messagePrefix)
+    }
+
+    /**
+     * Begin assertions for a single value
+     * @param actual the value we are testing
+     * @param messagePrefix an optional prefix to make the data more informative
+     */
+    @ExperimentalContracts
+    inline fun <reified T> assertThat(data: Data, key: String, messagePrefix: String = "data[$key] "): AssertThat<T> {
+        return assertThat(messagePrefix) {
+            data.getAs(key)
+        }
+    }
+
+    /**
+     * Begin assertions for a single value
+     * @param actual the value we are testing
+     * @param messagePrefix an optional prefix to make the data more informative
+     */
+    @ExperimentalContracts
+    inline fun <reified T> assertThat(messagePrefix: String = "", getFun: () -> MaybeData<*, T>): AssertThat<T> {
+        return when (val result = getFun()) {
+            is BadData -> {
+                fail("assertThat<${T::class.qualifiedName}>(${messagePrefix.trim()})",
+                    "${result.original} is a ${result.original?.let { it::class.qualifiedName } ?: "${T::class.qualifiedName}?"}")
+                AssertThatNoValue(result.original, messagePrefix)
+            }
+            is GoodData -> {
+                val value = result.value
+                // TODO Need to add ? for nullable types.
+                if (assertInstanceOf<T>("assertThat<${T::class.qualifiedName}>(${messagePrefix.trim()})", value)) {
+                    AssertThatValue(value, messagePrefix)
+                } else {
+                    AssertThatNoValue(value, messagePrefix)
+                }
+            }
+        }
+    }
+
+    fun assertTrue(message: String, test: Boolean?, value: Any? = null): Boolean {
+        return if (test != null && test) {
+            pass(message, value)
+            true
+        } else {
+            fail(message, value)
+            false
+        }
+    }
+
+    fun <T : Boolean?> AssertThat<T>.isTrue(message: String = "is true"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertTrue(this.messagePrefix + message, this.typedActual, this.actual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertFalse(message: String, test: Boolean?, right: Any? = null) {
         assertTrue(message, test?.not(), right)
     }
 
+    fun <T : Boolean?> AssertThat<T>.isFalse(message: String = "is false"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertFalse(this.messagePrefix + message, this.typedActual, this.actual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertEquals(message: String, left: Any?, right: Any?) {
         assertTrue(message, left == right, "$left == $right")
+    }
+
+    fun <T : Any?> AssertThat<T>.isEqualTo(expected: Any?, message: String = "is equal to $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertNotEquals(message: String, left: Any?, right: Any?) {
         assertTrue(message, left != right, "$left != $right")
     }
 
+    fun <T : Any?> AssertThat<T>.isNotEqualTo(expected: Boolean, message: String = "is not equal to $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertNotEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertLessThan(message: String, left: Int?, right: Int?) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
+    }
+
+    fun <T : Int?> AssertThat<T>.isLessThan(expected: Int, message: String = "is less than $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertLessThan(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertLessThan(message: String, left: Long?, right: Long?) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
     }
 
+    fun <T : Long?> AssertThat<T>.isLessThan(expected: Long, message: String = "is less than $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertLessThan(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertLessThan(message: String, left: Float?, right: Float?) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
+    }
+
+    fun <T : Float?> AssertThat<T>.isLessThan(expected: Float, message: String = "is less than $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertLessThan(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertLessThan(message: String, left: Double?, right: Double?) {
         assertTrue(message, left != null && right != null && left < right, "$left < $right")
     }
 
+    fun <T : Double?> AssertThat<T>.isLessThan(expected: Double, message: String = "is less than $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertLessThan(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertLessThanEquals(message: String, left: Int?, right: Int?) {
         assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
+    }
+
+    fun <T : Int?> AssertThat<T>.isLessThanEquals(expected: Int, message: String = "is less than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertLessThanEquals(message: String, left: Long?, right: Long?) {
         assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
+    fun <T : Long?> AssertThat<T>.isLessThanEquals(expected: Long, message: String = "is less than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertLessThanEquals(message: String, left: Float?, right: Float?) {
         assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
+    }
+
+    fun <T : Float?> AssertThat<T>.isLessThanEquals(expected: Float, message: String = "is less than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertLessThanEquals(message: String, left: Double?, right: Double?) {
         assertTrue(message, left != null && right != null && left <= right, "$left <= $right")
     }
 
+    fun <T : Double?> AssertThat<T>.isLessThanEquals(expected: Double, message: String = "is less than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertLessThanEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertGreaterThan(message: String, left: Int?, right: Int?) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
+    }
+
+    fun <T : Int?> AssertThat<T>.isGreaterThan(expected: Int, message: String = "is greater than $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertGreaterThan(message: String, left: Long?, right: Long?) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
+    fun <T : Long?> AssertThat<T>.isGreaterThan(expected: Long, message: String = "is greater than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertGreaterThan(message: String, left: Float?, right: Float?) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
+    }
+
+    fun <T : Float?> AssertThat<T>.isGreaterThan(expected: Float, message: String = "is greater than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertGreaterThan(message: String, left: Double?, right: Double?) {
         assertTrue(message, left != null && right != null && left > right, "$left > $right")
     }
 
+    fun <T : Double?> AssertThat<T>.isGreaterThan(expected: Double, message: String = "is greater than $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertGreaterThan(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertGreaterThanEquals(message: String, left: Int?, right: Int?) {
         assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
+    }
+
+    fun <T : Int?> AssertThat<T>.isGreaterThanEquals(expected: Int, message: String = "is greater than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertGreaterThanEquals(message: String, left: Long?, right: Long?) {
         assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
+    fun <T : Long?> AssertThat<T>.isGreaterThanEquals(expected: Long, message: String = "is greater than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertGreaterThanEquals(message: String, left: Float?, right: Float?) {
         assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
+    }
+
+    fun <T : Float?> AssertThat<T>.isGreaterThanEquals(expected: Float, message: String = "is greater than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertGreaterThanEquals(message: String, left: Double?, right: Double?) {
         assertTrue(message, left != null && right != null && left >= right, "$left >= $right")
     }
 
+    fun <T : Double?> AssertThat<T>.isGreaterThanEquals(expected: Double, message: String = "is greater than equals $expected"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertGreaterThanEquals(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertContains(message: String, collection: Collection<*>?, value: Any?) {
         assertTrue(message, collection?.contains(value) == true, "$value in $collection")
+    }
+
+    fun <T, C : Collection<T>?> AssertThat<C>.contains(expected: T, message: String = "contains $expected"): AssertThat<C> {
+        when (this) {
+            is AssertThatValue ->
+                assertContains(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertNotContains(message: String, collection: Collection<*>?, value: Any?) {
         assertTrue(message, collection?.contains(value) == false, "$value not in $collection")
     }
 
+    fun <T, C : Collection<T>?> AssertThat<C>.notContains(expected: T, message: String = "not contains $expected"): AssertThat<C> {
+        when (this) {
+            is AssertThatValue ->
+                assertNotContains(this.messagePrefix + message, this.typedActual, expected)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertEmpty(message: String, collection: Collection<*>?) {
         assertTrue(message, collection?.isEmpty() == true, collection)
+    }
+
+    fun <T : Collection<*>?> AssertThat<T>.isEmpty(message: String = "is empty"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertEmpty(this.messagePrefix + message, this.typedActual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertNullOrEmpty(message: String, collection: Collection<*>?) {
         assertTrue(message, collection.isNullOrEmpty(), collection)
     }
 
+    fun <T : Collection<*>?> AssertThat<T>.isNullOrEmpty(message: String = "is null or empty"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertNullOrEmpty(this.messagePrefix + message, this.typedActual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
     fun assertNotEmpty(message: String, collection: Collection<*>?) {
         assertTrue(message, collection?.isNotEmpty() == true, collection)
+    }
+
+    fun <T : Collection<*>?> AssertThat<T>.isNotEmpty(message: String = "is not empty"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertNotEmpty(this.messagePrefix + message, this.typedActual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
     fun assertSizeEquals(message: String, collection: Collection<*>?, size: Int) {
         assertTrue(message, collection?.size == size, "$size = size($collection)")
     }
 
-    fun assertNull(message: String, value: Any?) {
-        assertTrue(message, value == null, value)
+    fun <T : Collection<*>?> AssertThat<T>.isSizeEquals(size: Int, message: String = "is size equal to $size"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertSizeEquals(this.messagePrefix + message, this.typedActual, size)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
     }
 
-    fun assertNotNull(message: String, value: Any?) {
-        assertTrue(message, value != null, value)
+    @ExperimentalContracts
+    fun assertNull(message: String, value: Any?): Boolean {
+        contract {
+            returns(true) implies (value == null)
+        }
+        return assertTrue(message, value == null, value)
+    }
+
+    @ExperimentalContracts
+    fun <T : Any?> AssertThat<T>.isNull(message: String = "is null"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertNull(this.messagePrefix + message, this.typedActual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
+    @ExperimentalContracts
+    fun assertNotNull(message: String, value: Any?): Boolean {
+        contract {
+            returns(true) implies (value != null)
+        }
+        return assertTrue(message, value != null, value)
+    }
+
+    @ExperimentalContracts
+    fun <T : Any?> AssertThat<T>.isNotNull(message: String = "is not null"): AssertThat<T> {
+        when (this) {
+            is AssertThatValue ->
+                assertNotNull(this.messagePrefix + message, this.typedActual)
+            is AssertThatNoValue ->
+                fail(this.messagePrefix + message, this.actual)
+        }
+        return this
+    }
+
+    @ExperimentalContracts
+    inline fun <reified T> assertInstanceOf(message: String, value: Any?): Boolean {
+        contract {
+            returns(true) implies (value is T)
+        }
+        return assertTrue(message, value is T, "$value is a ${value?.let { it::class.qualifiedName } ?: "${T::class.qualifiedName}?"}")
     }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -556,10 +556,10 @@ class Assertions(val dataTrace: DataTrace) {
     /**
      *
      */
-    fun <T : Any?> AssertThat<T>.or(vararg ors: Assertions.(AssertThat<T>) -> Unit): AssertThat<T> {
+    fun or(vararg ors: Assertions.() -> Unit) {
         val testResults = ors.map { orFun ->
             val orAssertions = Assertions(dataTrace)
-            orAssertions.orFun(this)
+            orAssertions.orFun()
             orAssertions.results.toList()
         }
 
@@ -567,7 +567,5 @@ class Assertions(val dataTrace: DataTrace) {
             ?: testResults.flatten()
 
         firstSuccessOrAllErrors.forEach(this@Assertions::addValidationResult)
-
-        return this
     }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -1,6 +1,5 @@
 package com.shoprunner.baleen
 
-import com.shoprunner.baleen.Data.Companion.getAs
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
@@ -74,8 +73,8 @@ class Assertions(val dataTrace: DataTrace) {
         }
     }
 
-    fun AssertThat<Data>.hasAttribute(attribute: String, attributeAssertions: Assertions.(AssertThat<Any?>)-> Unit = {}): AssertThat<Data> {
-        when(this) {
+    fun AssertThat<Data>.hasAttribute(attribute: String, attributeAssertions: Assertions.(AssertThat<Any?>) -> Unit = {}): AssertThat<Data> {
+        when (this) {
             is AssertThatValue<Data> ->
                 if (this.typedActual.containsKey(attribute)) {
                     pass(messagePrefix + "data[$attribute] exists", this.typedActual)
@@ -382,7 +381,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.contains(value) == true, "$value in $collection")
     }
 
-    fun <T, C: Collection<T>> AssertThat<C>.contains(expected: T, message: String = "contains $expected"): AssertThat<C> {
+    fun <T, C : Collection<T>> AssertThat<C>.contains(expected: T, message: String = "contains $expected"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertContains(this.messagePrefix + message, this.typedActual, expected)
@@ -392,8 +391,8 @@ class Assertions(val dataTrace: DataTrace) {
         return this
     }
 
-    fun <T: Any?> AssertThat<T>.isOneOf(collection: Collection<T>, message: String = "is one of $collection"): AssertThat<T> {
-        when(this) {
+    fun <T : Any?> AssertThat<T>.isOneOf(collection: Collection<T>, message: String = "is one of $collection"): AssertThat<T> {
+        when (this) {
             is AssertThatValue ->
                 assertContains(this.messagePrefix + message, collection, this.typedActual)
             is AssertThatNoValue ->
@@ -406,7 +405,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.contains(value) == false, "$value not in $collection")
     }
 
-    fun <T, C: Collection<T>> AssertThat<C>.notContains(expected: T, message: String = "not contains $expected"): AssertThat<C> {
+    fun <T, C : Collection<T>> AssertThat<C>.notContains(expected: T, message: String = "not contains $expected"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertNotContains(this.messagePrefix + message, this.typedActual, expected)
@@ -420,7 +419,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.isEmpty() == true, collection)
     }
 
-    fun <T, C: Collection<T>> AssertThat<C>.isEmpty(message: String = "is empty"): AssertThat<C> {
+    fun <T, C : Collection<T>> AssertThat<C>.isEmpty(message: String = "is empty"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertEmpty(this.messagePrefix + message, this.typedActual)
@@ -434,7 +433,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection.isNullOrEmpty(), collection)
     }
 
-    fun <T, C: Collection<T>> AssertThat<C?>.isNullOrEmpty(message: String = "is null or empty"): AssertThat<C?> {
+    fun <T, C : Collection<T>> AssertThat<C?>.isNullOrEmpty(message: String = "is null or empty"): AssertThat<C?> {
         when (this) {
             is AssertThatValue ->
                 assertNullOrEmpty(this.messagePrefix + message, this.typedActual)
@@ -448,7 +447,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.isNotEmpty() == true, collection)
     }
 
-    fun <T, C: Collection<T>?> AssertThat<C>.isNotEmpty(message: String = "is not empty"): AssertThat<C> {
+    fun <T, C : Collection<T>?> AssertThat<C>.isNotEmpty(message: String = "is not empty"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertNotEmpty(this.messagePrefix + message, this.typedActual)
@@ -462,7 +461,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, collection?.size == size, "$size = size($collection)")
     }
 
-    fun <T, C: Collection<T>?> AssertThat<C>.isSizeEquals(size: Int, message: String = "is size equal to $size"): AssertThat<C> {
+    fun <T, C : Collection<T>?> AssertThat<C>.isSizeEquals(size: Int, message: String = "is size equal to $size"): AssertThat<C> {
         when (this) {
             is AssertThatValue ->
                 assertSizeEquals(this.messagePrefix + message, this.typedActual, size)
@@ -494,7 +493,7 @@ class Assertions(val dataTrace: DataTrace) {
     fun <T> AssertThat<T?>.isNullOr(message: String = "is null", body: Assertions.(AssertThat<T>) -> Unit): AssertThat<T?> {
         when (this) {
             is AssertThatValue -> {
-                when(typedActual) {
+                when (typedActual) {
                     null -> pass(messagePrefix + message, typedActual)
                     else -> body(AssertThatValue(typedActual, messagePrefix))
                 }
@@ -517,7 +516,7 @@ class Assertions(val dataTrace: DataTrace) {
     fun <T> AssertThat<T?>.isNotNull(message: String = "is not null"): AssertThat<T> {
         return when (this) {
             is AssertThatValue ->
-                if(assertNotNull(this.messagePrefix + message, this.typedActual)) {
+                if (assertNotNull(this.messagePrefix + message, this.typedActual)) {
                     AssertThatValue(this.typedActual, this.messagePrefix)
                 } else {
                     AssertThatNoValue(this.typedActual, this.messagePrefix)
@@ -540,7 +539,7 @@ class Assertions(val dataTrace: DataTrace) {
     inline fun <reified T : Any?> AssertThat<Any?>.isA(message: String = "is a ${T::class.qualifiedName}"): AssertThat<T> {
         return when (this) {
             is AssertThatValue ->
-                if(this.typedActual is T) {
+                if (this.typedActual is T) {
                     pass(messagePrefix + message, this.typedActual)
                     AssertThatValue(this.typedActual, this.messagePrefix)
                 } else {
@@ -557,7 +556,7 @@ class Assertions(val dataTrace: DataTrace) {
     /**
      *
      */
-    fun <T: Any?> AssertThat<T>.or(vararg ors: Assertions.(AssertThat<T>) -> Unit): AssertThat<T> {
+    fun <T : Any?> AssertThat<T>.or(vararg ors: Assertions.(AssertThat<T>) -> Unit): AssertThat<T> {
         val testResults = ors.map { orFun ->
             val orAssertions = Assertions(dataTrace)
             orAssertions.orFun(this)

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -137,7 +137,7 @@ class Assertions(val dataTrace: DataTrace) {
         assertTrue(message, left != right, "$left != $right")
     }
 
-    fun <T : Any?> AssertThat<T>.isNotEqualTo(expected: Boolean, message: String = "is not equal to $expected"): AssertThat<T> {
+    fun <T : Any?> AssertThat<T>.isNotEqualTo(expected: Any?, message: String = "is not equal to $expected"): AssertThat<T> {
         when (this) {
             is AssertThatValue ->
                 assertNotEquals(this.messagePrefix + message, this.typedActual, expected)

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Asserts.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Asserts.kt
@@ -1,0 +1,125 @@
+package com.shoprunner.baleen
+
+/**
+ * Simplify writing tests by using JUnit style assertions.
+ */
+class Asserts(val dataTrace: DataTrace) {
+    private var validationResults: Sequence<ValidationResult> = sequenceOf()
+
+    val results: Sequence<ValidationResult> get() = validationResults
+
+    fun addValidationResult(result: ValidationResult) {
+        validationResults += result
+    }
+
+    fun assertTrue(message: String, test: Boolean?, value: Any? = null) {
+        addValidationResult(
+            if (test != null && test) ValidationInfo(dataTrace.tag("assertion" to message), "Pass: $message", value)
+            else ValidationError(dataTrace.tag("assertion" to message), "Fail: $message", value)
+        )
+    }
+
+    fun assertFalse(message: String, test: Boolean?, right: Any?) {
+        assertTrue(message, test?.not(), right)
+    }
+
+    fun assertEquals(message: String, left: Any?, right: Any?) {
+        assertTrue(message, left == right, "$left == $right")
+    }
+
+    fun assertNotEquals(message: String, left: Any?, right: Any?) {
+        assertTrue(message, left != right, "$left != $right")
+    }
+
+    fun assertLessThan(message: String, left: Int?, right: Int?) {
+        assertTrue(message, left != null && right != null && left < right, "$left < $right")
+    }
+
+    fun assertLessThan(message: String, left: Long?, right: Long?) {
+        assertTrue(message, left != null && right != null && left < right, "$left < $right")
+    }
+
+    fun assertLessThan(message: String, left: Float?, right: Float?) {
+        assertTrue(message, left != null && right != null && left < right, "$left < $right")
+    }
+
+    fun assertLessThan(message: String, left: Double?, right: Double?) {
+        assertTrue(message, left != null && right != null && left < right, "$left < $right")
+    }
+
+    fun assertLessThanEqual(message: String, left: Int?, right: Int?) {
+        assertTrue(message, left != null && right != null && left <= right, "$left < $right")
+    }
+
+    fun assertLessThanEqual(message: String, left: Long?, right: Long?) {
+        assertTrue(message, left != null && right != null && left <= right, "$left < $right")
+    }
+
+    fun assertLessThanEqual(message: String, left: Float?, right: Float?) {
+        assertTrue(message, left != null && right != null && left <= right, "$left < $right")
+    }
+
+    fun assertLessThanEqual(message: String, left: Double?, right: Double?) {
+        assertTrue(message, left != null && right != null && left <= right, "$left < $right")
+    }
+
+    fun assertGreaterThan(message: String, left: Int?, right: Int?) {
+        assertTrue(message, left != null && right != null && left > right, "$left < $right")
+    }
+
+    fun assertGreaterThan(message: String, left: Long?, right: Long?) {
+        assertTrue(message, left != null && right != null && left > right, "$left < $right")
+    }
+
+    fun assertGreaterThan(message: String, left: Float?, right: Float?) {
+        assertTrue(message, left != null && right != null && left > right, "$left < $right")
+    }
+
+    fun assertGreaterThan(message: String, left: Double?, right: Double?) {
+        assertTrue(message, left != null && right != null && left > right, "$left < $right")
+    }
+
+    fun assertGreaterThanEqual(message: String, left: Int?, right: Int?) {
+        assertTrue(message, left != null && right != null && left >= right, "$left < $right")
+    }
+
+    fun assertGreaterThanEqual(message: String, left: Long?, right: Long?) {
+        assertTrue(message, left != null && right != null && left >= right, "$left < $right")
+    }
+
+    fun assertGreaterThanEqual(message: String, left: Float?, right: Float?) {
+        assertTrue(message, left != null && right != null && left >= right, "$left < $right")
+    }
+
+    fun assertGreaterThanEqual(message: String, left: Double?, right: Double?) {
+        assertTrue(message, left != null && right != null && left >= right, "$left < $right")
+    }
+
+    fun assertContains(message: String, collection: Collection<*>?, value: Any?) {
+        assertTrue(message, collection?.contains(value) == true, "$value in $collection")
+    }
+
+    fun assertNotContains(message: String, collection: Collection<*>?, value: Any?) {
+        assertTrue(message, collection?.contains(value) == false, "$value not in $collection")
+    }
+
+    fun assertIsEmpty(message: String, collection: Collection<*>?) {
+        assertTrue(message, collection?.isEmpty() == true, collection)
+    }
+
+    fun assertIsNotEmpty(message: String, collection: Collection<*>?) {
+        assertTrue(message, collection?.isNotEmpty() == true, collection)
+    }
+
+    fun assertSizeEquals(message: String, collection: Collection<*>, size: Int) {
+        assertTrue(message, collection.size == size, "$size = size($collection)")
+    }
+
+    fun assertNull(message: String, value: Any?) {
+        assertTrue(message, value == null, value)
+    }
+
+    fun assertNotNull(message: String, value: Any?) {
+        assertTrue(message, value != null, value)
+    }
+}

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
@@ -39,6 +39,15 @@ class AttributeDescription(
         return this
     }
 
+    fun AttributeDescription.test(testName: String, validator: Asserts.(Data) -> Unit): AttributeDescription {
+        this.test { dataTrace, data ->
+            val asserts = Asserts(dataTrace.tag("test" to testName))
+            asserts.validator(data)
+            asserts.results
+        }
+        return this
+    }
+
     fun describe(block: (AttributeDescription) -> Unit): AttributeDescription {
         block(this)
         return this

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
@@ -39,9 +39,9 @@ class AttributeDescription(
         return this
     }
 
-    fun AttributeDescription.test(testName: String, validator: Asserts.(Data) -> Unit): AttributeDescription {
+    fun AttributeDescription.test(testName: String, validator: Assertions.(Data) -> Unit): AttributeDescription {
         this.test { dataTrace, data ->
-            val asserts = Asserts(dataTrace.tag("test" to testName))
+            val asserts = Assertions(dataTrace.tag("test" to testName))
             asserts.validator(data)
             asserts.results
         }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/AttributeDescription.kt
@@ -39,9 +39,10 @@ class AttributeDescription(
         return this
     }
 
-    fun AttributeDescription.test(testName: String, validator: Assertions.(Data) -> Unit): AttributeDescription {
+    fun AttributeDescription.test(testName: String, vararg additionalTags: Pair<String, Tagger>, validator: Assertions.(Data) -> Unit): AttributeDescription {
         this.test { dataTrace, data ->
-            val asserts = Assertions(dataTrace.tag("test" to testName))
+            val additionalTestTags = additionalTags.map { (key, tagger) -> key to tagger(data) } + ("test" to testName)
+            val asserts = Assertions(dataTrace.tag(additionalTestTags.toMap()))
             asserts.validator(data)
             asserts.results
         }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Data.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Data.kt
@@ -9,4 +9,37 @@ interface Data {
     fun attributeDataValue(key: String, dataTrace: DataTrace): DataValue = DataValue(get(key), dataTrace + "attribute \"$key\"")
 
     val keys: Set<String>
+
+    /**
+     * Retrieve the value using the key and cast it into a String or throw an Exception
+     */
+    fun getAsString(key: String): String? = getAs(key)
+
+    /**
+     * Retrieve the value using the key and cast it into a String or throw an Exception
+     */
+    fun getAsInt(key: String): Int? = getAs(key)
+
+    /**
+     * Retrieve the value using the key and cast it into a String or throw an Exception
+     */
+    fun getAsLong(key: String): Long? = getAs(key)
+
+    /**
+     * Retrieve the value using the key and cast it into a String or throw an Exception
+     */
+    fun getAsFloat(key: String): Float? = getAs(key)
+
+    /**
+     * Retrieve the value using the key and cast it into a String or throw an Exception
+     */
+    fun getAsDouble(key: String): Double? = getAs(key)
+
+    companion object {
+        /**
+         * Retrieve the value using the key directly and casts it into expected value or throw Exception
+         */
+        inline fun <reified T> Data.getAs(key: String): T? = this[key]?.takeIf { it is T }?.let { it as T }
+            ?: throw IllegalArgumentException("Cannot cast $this to expected type ${T::class}")
+    }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Data.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Data.kt
@@ -13,33 +13,48 @@ interface Data {
     /**
      * Retrieve the value using the key and cast it into a String or throw an Exception
      */
-    fun getAsString(key: String): String? = getAs(key)
+    fun getAsString(key: String): MaybeData<Exception, String?> = getAs(key)
+    fun getAsStringOrNull(key: String): String? = getAs<String?>(key).getOrNull()
+    fun getAsStringOrThrow(key: String): String? = getAs<String?>(key).getOrThrow()
 
     /**
      * Retrieve the value using the key and cast it into a String or throw an Exception
      */
-    fun getAsInt(key: String): Int? = getAs(key)
+    fun getAsInt(key: String): MaybeData<Exception, Int?> = getAs(key)
+    fun getAsIntOrNull(key: String): Int? = getAs<Int?>(key).getOrNull()
+    fun getAsIntOrThrow(key: String): Int? = getAs<Int?>(key).getOrThrow()
 
     /**
      * Retrieve the value using the key and cast it into a String or throw an Exception
      */
-    fun getAsLong(key: String): Long? = getAs(key)
+    fun getAsLong(key: String): MaybeData<Exception, Long?> = getAs(key)
+    fun getAsLongOrNull(key: String): Long? = getAs<Long?>(key).getOrNull()
+    fun getAsLongOrThrow(key: String): Long? = getAs<Long?>(key).getOrThrow()
 
     /**
      * Retrieve the value using the key and cast it into a String or throw an Exception
      */
-    fun getAsFloat(key: String): Float? = getAs(key)
+    fun getAsFloat(key: String): MaybeData<Exception, Float?> = getAs(key)
+    fun getAsFloatOrNull(key: String): Float? = getAs<Float?>(key).getOrNull()
+    fun getAsFloatOrThrow(key: String): Float? = getAs<Float?>(key).getOrThrow()
 
     /**
      * Retrieve the value using the key and cast it into a String or throw an Exception
      */
-    fun getAsDouble(key: String): Double? = getAs(key)
+    fun getAsDouble(key: String): MaybeData<Exception, Double?> = getAs(key)
+    fun getAsDoubleOrNull(key: String): Double? = getAs<Double?>(key).getOrNull()
+    fun getAsDoubleOrThrow(key: String): Double? = getAs<Double?>(key).getOrThrow()
 
     companion object {
         /**
          * Retrieve the value using the key directly and casts it into expected value or throw Exception
          */
-        inline fun <reified T> Data.getAs(key: String): T? = this[key]?.takeIf { it is T }?.let { it as T }
-            ?: throw IllegalArgumentException("Cannot cast $this to expected type ${T::class}")
+        inline fun <reified T> Data.getAs(key: String): MaybeData<Exception, T> = try {
+            GoodData(this[key] as T)
+        } catch (e: ClassCastException) {
+            BadData(e, this[key])
+        } catch (e: NullPointerException) {
+            BadData(e, this[key])
+        }
     }
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/DataDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/DataDescription.kt
@@ -72,6 +72,15 @@ class DataDescription(
         tests.add(validation)
     }
 
+    fun test(testName: String, validator: Asserts.(Data) -> Unit): DataDescription {
+        this.test { dataTrace, data ->
+            val asserts = Asserts(dataTrace.tag("test" to testName))
+            asserts.validator(data)
+            asserts.results
+        }
+        return this
+    }
+
     private val allTests: List<Validator>
         get() = attrs.flatMap { it.allTests } + tests
 }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/DataDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/DataDescription.kt
@@ -72,9 +72,9 @@ class DataDescription(
         tests.add(validation)
     }
 
-    fun test(testName: String, validator: Asserts.(Data) -> Unit): DataDescription {
+    fun test(testName: String, validator: Assertions.(Data) -> Unit): DataDescription {
         this.test { dataTrace, data ->
-            val asserts = Asserts(dataTrace.tag("test" to testName))
+            val asserts = Assertions(dataTrace.tag("test" to testName))
             asserts.validator(data)
             asserts.results
         }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/DataDescription.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/DataDescription.kt
@@ -1,5 +1,7 @@
 package com.shoprunner.baleen
 
+import com.shoprunner.baleen.types.Tagger
+
 class DataDescription(
     val name: String,
     val nameSpace: String = "",
@@ -72,9 +74,10 @@ class DataDescription(
         tests.add(validation)
     }
 
-    fun test(testName: String, validator: Assertions.(Data) -> Unit): DataDescription {
+    fun test(testName: String, vararg additionalTags: Pair<String, Tagger>, validator: Assertions.(Data) -> Unit): DataDescription {
         this.test { dataTrace, data ->
-            val asserts = Assertions(dataTrace.tag("test" to testName))
+            val additionalTestTags = additionalTags.map { (key, tagger) -> key to tagger(data) } + ("test" to testName)
+            val asserts = Assertions(dataTrace.tag(additionalTestTags.toMap()))
             asserts.validator(data)
             asserts.results
         }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/MaybeData.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/MaybeData.kt
@@ -1,18 +1,57 @@
 package com.shoprunner.baleen
 
 /**
- * Base class for good or bad data.
+ * Data retrieved can be either "good" because it is of the correct type. Or it is "bad"
+ * and some Throwable was created.
+ *
+ * @param original the original data if present or null.
  */
 sealed class MaybeData<E : Throwable, T>(val original: Any?) {
+    /**
+     * Retrieve the value or throw the Throwable.
+     *
+     * @return the value
+     * @throws E if bad data
+     */
     abstract fun getOrThrow(): T
+
+    /**
+     * Retrieve the value or return null.
+     *
+     * @return the value or null
+     */
     abstract fun getOrNull(): T?
+
+    /**
+     * Given a function, apply the function on the value and return a new MaybeData.
+     * @param f map function taking T and returning R
+     * @throws Throwable if one occurs in the map function
+     */
     abstract fun <R> map(f: (T) -> R): MaybeData<E, R>
+
+    /**
+     * Given a function, apply the function on the value and return a new MaybeData. If a
+     * Throwable occurs, then the error is handled by returning [BadData].
+     *
+     * @param f map function taking T and returning R
+     * @return [GoodData] if mapping is successful or [BadData] if error occures.
+     */
     abstract fun <R> tryMap(f: (T) -> R): MaybeData<Throwable, R>
+
+    /**
+     * Given a function that also returns [MaybeData], apply that function and return the result.
+     *
+     * @param f map function taking T and returning [MaybeData]<E2, R>
+     * @return [MaybeData] from [f] or [BadData] if this has an exception.
+     */
     abstract fun <E2 : Throwable, R> flatMap(f: (T) -> MaybeData<E2, R>): MaybeData<Throwable, R>
 }
 
 /**
  * Bad data. Contains the exception as well as the original value
+ *
+ * @param error the throwable error that occurred.
+ * @param original the original data if present or null.
  */
 class BadData<E : Throwable, T>(val error: E, original: Any?) : MaybeData<E, T>(original) {
     override fun getOrThrow(): T = throw error
@@ -25,6 +64,9 @@ class BadData<E : Throwable, T>(val error: E, original: Any?) : MaybeData<E, T>(
 
 /**
  * Good Data. Contains the correct value with the correct type.
+ *
+ * @param value the value correctly typed.
+ * @param original the original data if present or null.
  */
 class GoodData<E : Throwable, T>(val value: T, original: Any? = value) : MaybeData<E, T>(original) {
     override fun getOrThrow(): T = value
@@ -43,4 +85,9 @@ class GoodData<E : Throwable, T>(val value: T, original: Any? = value) : MaybeDa
         }
 }
 
+/**
+ * Flatten nested [MaybeData]'s calling [MaybeData.flatMap].
+ *
+ * @return flattened [MaybeData].
+ */
 fun <T> MaybeData<*, MaybeData<*, T>>.flatten(): MaybeData<Throwable, T> = this.flatMap { it }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/MaybeData.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/MaybeData.kt
@@ -6,6 +6,8 @@ package com.shoprunner.baleen
 sealed class MaybeData<E : Throwable, T>(val original: Any?) {
     abstract fun getOrThrow(): T
     abstract fun getOrNull(): T?
+    abstract fun <R> map(f: (T)-> R): MaybeData<E, R>
+    abstract fun <E2: Throwable, R> flatMap(f: (T)-> MaybeData<E2,R>): MaybeData<Throwable, R>
 }
 
 /**
@@ -14,6 +16,9 @@ sealed class MaybeData<E : Throwable, T>(val original: Any?) {
 class BadData<E : Throwable, T>(val error: E, original: Any?) : MaybeData<E, T>(original) {
     override fun getOrThrow(): T = throw error
     override fun getOrNull(): T? = null
+    override fun <R> map(f: (T) -> R): MaybeData<E, R> = BadData(this.error, this.original)
+    override fun <E2: Throwable, R> flatMap(f: (T) -> MaybeData<E2, R>): MaybeData<Throwable, R> =
+        BadData(this.error, this.original)
 }
 
 /**
@@ -22,4 +27,12 @@ class BadData<E : Throwable, T>(val error: E, original: Any?) : MaybeData<E, T>(
 class GoodData<E : Throwable, T>(val value: T) : MaybeData<E, T>(value) {
     override fun getOrThrow(): T = value
     override fun getOrNull(): T? = value
+    override fun <R> map(f: (T) -> R): MaybeData<E, R> = GoodData(f(this.value))
+    override fun <E2 : Throwable, R> flatMap(f: (T) -> MaybeData<E2, R>): MaybeData<Throwable, R> =
+        when(val result = f(this.value)) {
+            is GoodData -> GoodData(result.value)
+            is BadData -> BadData(result.error, result.original)
+        }
 }
+
+fun <T> MaybeData<*, MaybeData<*, T>>.flatten(): MaybeData<Throwable, T> = this.flatMap { it }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/MaybeData.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/MaybeData.kt
@@ -6,8 +6,8 @@ package com.shoprunner.baleen
 sealed class MaybeData<E : Throwable, T>(val original: Any?) {
     abstract fun getOrThrow(): T
     abstract fun getOrNull(): T?
-    abstract fun <R> map(f: (T)-> R): MaybeData<E, R>
-    abstract fun <E2: Throwable, R> flatMap(f: (T)-> MaybeData<E2,R>): MaybeData<Throwable, R>
+    abstract fun <R> map(f: (T) -> R): MaybeData<E, R>
+    abstract fun <E2 : Throwable, R> flatMap(f: (T) -> MaybeData<E2, R>): MaybeData<Throwable, R>
 }
 
 /**
@@ -17,7 +17,7 @@ class BadData<E : Throwable, T>(val error: E, original: Any?) : MaybeData<E, T>(
     override fun getOrThrow(): T = throw error
     override fun getOrNull(): T? = null
     override fun <R> map(f: (T) -> R): MaybeData<E, R> = BadData(this.error, this.original)
-    override fun <E2: Throwable, R> flatMap(f: (T) -> MaybeData<E2, R>): MaybeData<Throwable, R> =
+    override fun <E2 : Throwable, R> flatMap(f: (T) -> MaybeData<E2, R>): MaybeData<Throwable, R> =
         BadData(this.error, this.original)
 }
 
@@ -29,7 +29,7 @@ class GoodData<E : Throwable, T>(val value: T) : MaybeData<E, T>(value) {
     override fun getOrNull(): T? = value
     override fun <R> map(f: (T) -> R): MaybeData<E, R> = GoodData(f(this.value))
     override fun <E2 : Throwable, R> flatMap(f: (T) -> MaybeData<E2, R>): MaybeData<Throwable, R> =
-        when(val result = f(this.value)) {
+        when (val result = f(this.value)) {
             is GoodData -> GoodData(result.value)
             is BadData -> BadData(result.error, result.original)
         }

--- a/baleen/src/main/kotlin/com/shoprunner/baleen/MaybeData.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/MaybeData.kt
@@ -1,0 +1,25 @@
+package com.shoprunner.baleen
+
+/**
+ * Base class for good or bad data.
+ */
+sealed class MaybeData<E : Throwable, T>(val original: Any?) {
+    abstract fun getOrThrow(): T
+    abstract fun getOrNull(): T?
+}
+
+/**
+ * Bad data. Contains the exception as well as the original value
+ */
+class BadData<E : Throwable, T>(val error: E, original: Any?) : MaybeData<E, T>(original) {
+    override fun getOrThrow(): T = throw error
+    override fun getOrNull(): T? = null
+}
+
+/**
+ * Good Data. Contains the correct value with the correct type.
+ */
+class GoodData<E : Throwable, T>(val value: T) : MaybeData<E, T>(value) {
+    override fun getOrThrow(): T = value
+    override fun getOrNull(): T? = value
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -1,5 +1,6 @@
 package com.shoprunner.baleen
 
+import com.shoprunner.baleen.Data.Companion.getAs
 import com.shoprunner.baleen.TestHelper.dataOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -9,6 +10,28 @@ import org.assertj.core.api.Assertions.assertThat as junitAssertThat
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExperimentalContracts
 internal class AssertThatTest {
+
+    @Test
+    fun `test assertThat with getAs`() {
+        val data = dataOf(
+            "value" to "true",
+        )
+        with(Assertions(dataTrace())) {
+            assertThat { data.getAs<String>("value")}
+            assertThat { data.getAs<Boolean>("value")}
+            assertThat { data.getAs<String>("value").tryMap { it.toBoolean() } }
+            assertThat { data.getAs<String>("value").tryMap { it.toInt() } }
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "assertThat<kotlin.String>()"), "Pass: assertThat<kotlin.String>()", "true is a kotlin.String"),
+                ValidationError(dataTrace().tag("assertion" to "assertThat<kotlin.Boolean>()"), "Fail: assertThat<kotlin.Boolean>()", "true is a kotlin.String"),
+                ValidationInfo(dataTrace().tag("assertion" to "assertThat<kotlin.Boolean>()"), "Pass: assertThat<kotlin.Boolean>()", "true is a kotlin.Boolean"),
+                ValidationError(dataTrace().tag("assertion" to "assertThat<kotlin.Int>()"), "Fail: assertThat<kotlin.Int>()", "true is a kotlin.String"),
+            )
+        }
+    }
 
     @Test
     fun `test assertThat validate instance of`() {

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -1,0 +1,522 @@
+package com.shoprunner.baleen
+
+import com.shoprunner.baleen.TestHelper.dataOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.contracts.ExperimentalContracts
+import org.assertj.core.api.Assertions.assertThat as junitAssertThat
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExperimentalContracts
+internal class AssertThatTest {
+
+    @Test
+    fun `test assertThat validate instance of`() {
+        val data = dataOf(
+            "value" to true,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<Boolean>(data, "value")
+            assertThat<String>(data, "value")
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "assertThat<kotlin.Boolean>(data[value])"), "Pass: assertThat<kotlin.Boolean>(data[value])", "true is a kotlin.Boolean"),
+                ValidationError(dataTrace().tag("assertion" to "assertThat<kotlin.String>(data[value])"), "Fail: assertThat<kotlin.String>(data[value])", "true is a kotlin.Boolean"),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat validate instance of nullable type`() {
+        val data = dataOf(
+            "value" to null,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<Boolean?>(data, "value")
+            assertThat<Boolean>(data, "value")
+
+            junitAssertThat(this.results.toList()).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "assertThat<kotlin.Boolean>(data[value])"), "Pass: assertThat<kotlin.Boolean>(data[value])", "null is a kotlin.Boolean?"),
+                ValidationError(dataTrace().tag("assertion" to "assertThat<kotlin.Boolean>(data[value])"), "Fail: assertThat<kotlin.Boolean>(data[value])", "null is a kotlin.Boolean?"),
+            )
+        }
+    }
+
+
+    @Test
+    fun `test assertThat Boolean isTrue`() {
+        val data = dataOf(
+            "value1" to true,
+            "value2" to false,
+            "value3" to "Hello World"
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<Boolean>(data, "value1").isTrue()
+            assertThat<Boolean>(data, "value2").isTrue()
+            assertThat<Boolean>(data, "value3").isTrue()
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value1] is true"), "Pass: data[value1] is true", true),
+                ValidationError(dataTrace().tag("assertion" to "data[value2] is true"), "Fail: data[value2] is true", false),
+                ValidationError(dataTrace().tag("assertion" to "data[value3] is true"), "Fail: data[value3] is true", "Hello World"),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat Boolean isFalse`() {
+        val data = dataOf(
+            "value1" to true,
+            "value2" to false,
+            "value3" to "Hello World"
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<Boolean>(data, "value1").isFalse()
+            assertThat<Boolean>(data, "value2").isFalse()
+            assertThat<Boolean>(data, "value3").isFalse()
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationError(dataTrace().tag("assertion" to "data[value1] is false"), "Fail: data[value1] is false", true),
+                ValidationInfo(dataTrace().tag("assertion" to "data[value2] is false"), "Pass: data[value2] is false", false),
+                ValidationError(dataTrace().tag("assertion" to "data[value3] is false"), "Fail: data[value3] is false", "Hello World"),
+            )
+        }
+    }
+//
+//    @Test
+//    fun `test assertEquals`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertEquals("test 1 = 1", 1, 1)
+//        assertions.assertEquals("test 1 = 2", 1, 2)
+//        assertions.assertEquals("test \"hello\" = \"hello\"", "hello", "hello")
+//        assertions.assertEquals("test \"hello\" = \"world\"", "hello", "world")
+//        assertions.assertEquals("test null = null", null, null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 = 1"), "Pass: test 1 = 1", "1 == 1"),
+//            ValidationError(dataTrace().tag("assertion" to "test 1 = 2"), "Fail: test 1 = 2", "1 == 2"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" = \"hello\""), "Pass: test \"hello\" = \"hello\"", "hello == hello"),
+//            ValidationError(dataTrace().tag("assertion" to "test \"hello\" = \"world\""), "Fail: test \"hello\" = \"world\"", "hello == world"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test null = null"), "Pass: test null = null", "null == null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertNotEquals`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertNotEquals("test 1 != 1", 1, 1)
+//        assertions.assertNotEquals("test 1 != 2", 1, 2)
+//        assertions.assertNotEquals("test \"hello\" != \"hello\"", "hello", "hello")
+//        assertions.assertNotEquals("test \"hello\" != \"world\"", "hello", "world")
+//        assertions.assertNotEquals("test null != null", null, null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 != 1"), "Fail: test 1 != 1", "1 != 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 != 2"), "Pass: test 1 != 2", "1 != 2"),
+//            ValidationError(dataTrace().tag("assertion" to "test \"hello\" != \"hello\""), "Fail: test \"hello\" != \"hello\"", "hello != hello"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" != \"world\""), "Pass: test \"hello\" != \"world\"", "hello != world"),
+//            ValidationError(dataTrace().tag("assertion" to "test null != null"), "Fail: test null != null", "null != null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertLessThan(Int)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertLessThan("test 1 < 1", 1.toInt(), 1)
+//        assertions.assertLessThan("test 1 < 2", 1.toInt(), 2)
+//        assertions.assertLessThan("test null < null", null?.toInt(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 < 1"), "Fail: test 1 < 1", "1 < 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 < 2"), "Pass: test 1 < 2", "1 < 2"),
+//            ValidationError(dataTrace().tag("assertion" to "test null < null"), "Fail: test null < null", "null < null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertLessThan(Long)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertLessThan("test 1 < 1", 1L, 1L)
+//        assertions.assertLessThan("test 1 < 2", 1L, 2L)
+//        assertions.assertLessThan("test null < null", null?.toLong(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 < 1"), "Fail: test 1 < 1", "1 < 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 < 2"), "Pass: test 1 < 2", "1 < 2"),
+//            ValidationError(dataTrace().tag("assertion" to "test null < null"), "Fail: test null < null", "null < null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertLessThan(Float)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertLessThan("test 1 < 1", 1f, 1f)
+//        assertions.assertLessThan("test 1 < 2", 1f, 2f)
+//        assertions.assertLessThan("test null < null", null?.toFloat(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 < 1"), "Fail: test 1 < 1", "1.0 < 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 < 2"), "Pass: test 1 < 2", "1.0 < 2.0"),
+//            ValidationError(dataTrace().tag("assertion" to "test null < null"), "Fail: test null < null", "null < null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertLessThan(Double)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertLessThan("test 1 < 1", 1.0, 1.0)
+//        assertions.assertLessThan("test 1 < 2", 1.0, 2.0)
+//        assertions.assertLessThan("test null < null", null?.toDouble(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 < 1"), "Fail: test 1 < 1", "1.0 < 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 < 2"), "Pass: test 1 < 2", "1.0 < 2.0"),
+//            ValidationError(dataTrace().tag("assertion" to "test null < null"), "Fail: test null < null", "null < null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertLessThanEquals(Int)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertLessThanEquals("test 1 <= 0", 1.toInt(), 0)
+//        assertions.assertLessThanEquals("test 1 <= 1", 1.toInt(), 1)
+//        assertions.assertLessThanEquals("test 1 <= 2", 1.toInt(), 2)
+//        assertions.assertLessThanEquals("test null <= null", null?.toInt(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 <= 0"), "Fail: test 1 <= 0", "1 <= 0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 1"), "Pass: test 1 <= 1", "1 <= 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 2"), "Pass: test 1 <= 2", "1 <= 2"),
+//            ValidationError(dataTrace().tag("assertion" to "test null <= null"), "Fail: test null <= null", "null <= null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertLessThanEquals(Long)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertLessThanEquals("test 1 <= 0", 1L, 0)
+//        assertions.assertLessThanEquals("test 1 <= 1", 1L, 1L)
+//        assertions.assertLessThanEquals("test 1 <= 2", 1L, 2L)
+//        assertions.assertLessThanEquals("test null <= null", null?.toLong(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 <= 0"), "Fail: test 1 <= 0", "1 <= 0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 1"), "Pass: test 1 <= 1", "1 <= 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 2"), "Pass: test 1 <= 2", "1 <= 2"),
+//            ValidationError(dataTrace().tag("assertion" to "test null <= null"), "Fail: test null <= null", "null <= null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertLessThanEquals(Float)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertLessThanEquals("test 1 <= 0", 1f, 0f)
+//        assertions.assertLessThanEquals("test 1 <= 1", 1f, 1f)
+//        assertions.assertLessThanEquals("test 1 <= 2", 1f, 2f)
+//        assertions.assertLessThanEquals("test null <= null", null?.toFloat(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 <= 0"), "Fail: test 1 <= 0", "1.0 <= 0.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 1"), "Pass: test 1 <= 1", "1.0 <= 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 2"), "Pass: test 1 <= 2", "1.0 <= 2.0"),
+//            ValidationError(dataTrace().tag("assertion" to "test null <= null"), "Fail: test null <= null", "null <= null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertLessThanEquals(Double)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertLessThanEquals("test 1 <= 0", 1.0, 0.0)
+//        assertions.assertLessThanEquals("test 1 <= 1", 1.0, 1.0)
+//        assertions.assertLessThanEquals("test 1 <= 2", 1.0, 2.0)
+//        assertions.assertLessThanEquals("test null <= null", null?.toDouble(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 <= 0"), "Fail: test 1 <= 0", "1.0 <= 0.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 1"), "Pass: test 1 <= 1", "1.0 <= 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 2"), "Pass: test 1 <= 2", "1.0 <= 2.0"),
+//            ValidationError(dataTrace().tag("assertion" to "test null <= null"), "Fail: test null <= null", "null <= null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertGreaterThan(Int)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertGreaterThan("test 1 > 1", 1.toInt(), 1)
+//        assertions.assertGreaterThan("test 2 > 1", 2.toInt(), 1)
+//        assertions.assertGreaterThan("test null > null", null?.toInt(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 > 1"), "Fail: test 1 > 1", "1 > 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 2 > 1"), "Pass: test 2 > 1", "2 > 1"),
+//            ValidationError(dataTrace().tag("assertion" to "test null > null"), "Fail: test null > null", "null > null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertGreaterThan(Long)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertGreaterThan("test 1 > 1", 1L, 1L)
+//        assertions.assertGreaterThan("test 2 > 1", 2L, 1L)
+//        assertions.assertGreaterThan("test null > null", null?.toLong(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 > 1"), "Fail: test 1 > 1", "1 > 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 2 > 1"), "Pass: test 2 > 1", "2 > 1"),
+//            ValidationError(dataTrace().tag("assertion" to "test null > null"), "Fail: test null > null", "null > null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertGreaterThan(Float)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertGreaterThan("test 1 > 1", 1f, 1f)
+//        assertions.assertGreaterThan("test 2 > 1", 2f, 1f)
+//        assertions.assertGreaterThan("test null > null", null?.toFloat(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 > 1"), "Fail: test 1 > 1", "1.0 > 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 2 > 1"), "Pass: test 2 > 1", "2.0 > 1.0"),
+//            ValidationError(dataTrace().tag("assertion" to "test null > null"), "Fail: test null > null", "null > null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertGreaterThan(Double)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertGreaterThan("test 1 > 1", 1.0, 1.0)
+//        assertions.assertGreaterThan("test 2 > 1", 2.0, 1.0)
+//        assertions.assertGreaterThan("test null > null", null?.toDouble(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 > 1"), "Fail: test 1 > 1", "1.0 > 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 2 > 1"), "Pass: test 2 > 1", "2.0 > 1.0"),
+//            ValidationError(dataTrace().tag("assertion" to "test null > null"), "Fail: test null > null", "null > null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertGreaterThanEquals(Int)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertGreaterThanEquals("test 0 >= 1", 0.toInt(), 1)
+//        assertions.assertGreaterThanEquals("test 1 >= 1", 1.toInt(), 1)
+//        assertions.assertGreaterThanEquals("test 2 >= 1", 2.toInt(), 1)
+//        assertions.assertGreaterThanEquals("test null >= null", null?.toInt(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 0 >= 1"), "Fail: test 0 >= 1", "0 >= 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 >= 1"), "Pass: test 1 >= 1", "1 >= 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 2 >= 1"), "Pass: test 2 >= 1", "2 >= 1"),
+//            ValidationError(dataTrace().tag("assertion" to "test null >= null"), "Fail: test null >= null", "null >= null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertGreaterThanEquals(Long)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertGreaterThanEquals("test 0 >= 1", 0L, 1)
+//        assertions.assertGreaterThanEquals("test 1 >= 1", 1L, 1L)
+//        assertions.assertGreaterThanEquals("test 2 >= 1", 2L, 1L)
+//        assertions.assertGreaterThanEquals("test null >= null", null?.toLong(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 0 >= 1"), "Fail: test 0 >= 1", "0 >= 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 >= 1"), "Pass: test 1 >= 1", "1 >= 1"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 2 >= 1"), "Pass: test 2 >= 1", "2 >= 1"),
+//            ValidationError(dataTrace().tag("assertion" to "test null >= null"), "Fail: test null >= null", "null >= null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertGreaterThanEquals(Float)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertGreaterThanEquals("test 0 >= 1", 0f, 1f)
+//        assertions.assertGreaterThanEquals("test 1 >= 1", 1f, 1f)
+//        assertions.assertGreaterThanEquals("test 2 >= 1", 2f, 1f)
+//        assertions.assertGreaterThanEquals("test null >= null", null?.toFloat(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 0 >= 1"), "Fail: test 0 >= 1", "0.0 >= 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 >= 1"), "Pass: test 1 >= 1", "1.0 >= 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 2 >= 1"), "Pass: test 2 >= 1", "2.0 >= 1.0"),
+//            ValidationError(dataTrace().tag("assertion" to "test null >= null"), "Fail: test null >= null", "null >= null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertGreaterThanEquals(Double)`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertGreaterThanEquals("test 0 >= 1", 0.0, 1.0)
+//        assertions.assertGreaterThanEquals("test 1 >= 1", 1.0, 1.0)
+//        assertions.assertGreaterThanEquals("test 2 >= 1", 2.0, 1.0)
+//        assertions.assertGreaterThanEquals("test null >= null", null?.toDouble(), null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 0 >= 1"), "Fail: test 0 >= 1", "0.0 >= 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 >= 1"), "Pass: test 1 >= 1", "1.0 >= 1.0"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 2 >= 1"), "Pass: test 2 >= 1", "2.0 >= 1.0"),
+//            ValidationError(dataTrace().tag("assertion" to "test null >= null"), "Fail: test null >= null", "null >= null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertContains`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertContains("test 1 in [1,2,3]", listOf(1,2,3), 1)
+//        assertions.assertContains("test 1 in []", emptyList<Int>(), 1)
+//        assertions.assertContains("test null in [1,2,3]", listOf(1,2,3), null)
+//        assertions.assertContains("test 1 in null", null, 1)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 in [1,2,3]"), "Pass: test 1 in [1,2,3]", "1 in [1, 2, 3]"),
+//            ValidationError(dataTrace().tag("assertion" to "test 1 in []"), "Fail: test 1 in []", "1 in []"),
+//            ValidationError(dataTrace().tag("assertion" to "test null in [1,2,3]"), "Fail: test null in [1,2,3]", "null in [1, 2, 3]"),
+//            ValidationError(dataTrace().tag("assertion" to "test 1 in null"), "Fail: test 1 in null", "1 in null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertNotContains`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertNotContains("test 1 !in [1,2,3]", listOf(1,2,3), 1)
+//        assertions.assertNotContains("test 1 !in []", emptyList<Int>(), 1)
+//        assertions.assertNotContains("test null !in [1,2,3]", listOf(1,2,3), null)
+//        assertions.assertNotContains("test 1 !in null", null, 1)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test 1 !in [1,2,3]"), "Fail: test 1 !in [1,2,3]", "1 not in [1, 2, 3]"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test 1 !in []"), "Pass: test 1 !in []", "1 not in []"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test null !in [1,2,3]"), "Pass: test null !in [1,2,3]", "null not in [1, 2, 3]"),
+//            ValidationError(dataTrace().tag("assertion" to "test 1 !in null"), "Fail: test 1 !in null", "1 not in null"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertEmpty`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertEmpty("test [1,2,3] is empty", listOf(1,2,3))
+//        assertions.assertEmpty("test [] is empty", emptyList<Int>())
+//        assertions.assertEmpty("test null is empty", null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test [1,2,3] is empty"), "Fail: test [1,2,3] is empty", listOf(1, 2, 3)),
+//            ValidationInfo(dataTrace().tag("assertion" to "test [] is empty"), "Pass: test [] is empty", emptyList<Int>()),
+//            ValidationError(dataTrace().tag("assertion" to "test null is empty"), "Fail: test null is empty", null),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertNullOrEmpty`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertNullOrEmpty("test [1,2,3] is null or empty", listOf(1,2,3))
+//        assertions.assertNullOrEmpty("test [] is null or empty", emptyList<Int>())
+//        assertions.assertNullOrEmpty("test null is null or empty", null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test [1,2,3] is null or empty"), "Fail: test [1,2,3] is null or empty", listOf(1, 2, 3)),
+//            ValidationInfo(dataTrace().tag("assertion" to "test [] is null or empty"), "Pass: test [] is null or empty", emptyList<Int>()),
+//            ValidationInfo(dataTrace().tag("assertion" to "test null is null or empty"), "Pass: test null is null or empty", null),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertNotEmpty`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertNotEmpty("test [1,2,3] is not empty", listOf(1,2,3))
+//        assertions.assertNotEmpty("test [] is not empty", emptyList<Int>())
+//        assertions.assertNotEmpty("test null is not empty", null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationInfo(dataTrace().tag("assertion" to "test [1,2,3] is not empty"), "Pass: test [1,2,3] is not empty", listOf(1, 2, 3)),
+//            ValidationError(dataTrace().tag("assertion" to "test [] is not empty"), "Fail: test [] is not empty", emptyList<Int>()),
+//            ValidationError(dataTrace().tag("assertion" to "test null is not empty"), "Fail: test null is not empty", null),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertSizeEquals`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertSizeEquals("test [1,2,3] is length 3", listOf(1,2,3), 3)
+//        assertions.assertSizeEquals("test [] is length 3", emptyList<Int>(), 3)
+//        assertions.assertSizeEquals("test null is length 3", null, 3)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationInfo(dataTrace().tag("assertion" to "test [1,2,3] is length 3"), "Pass: test [1,2,3] is length 3", "3 = size([1, 2, 3])"),
+//            ValidationError(dataTrace().tag("assertion" to "test [] is length 3"), "Fail: test [] is length 3", "3 = size([])"),
+//            ValidationError(dataTrace().tag("assertion" to "test null is length 3"), "Fail: test null is length 3", "3 = size(null)"),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertNull`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertNull("test \"hello\" is null", "hello")
+//        assertions.assertNull("test null is null", null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationError(dataTrace().tag("assertion" to "test \"hello\" is null"), "Fail: test \"hello\" is null", "hello"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test null is null"), "Pass: test null is null", null),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertNotNull`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertNotNull("test \"hello\" is not null", "hello")
+//        assertions.assertNotNull("test null is not null", null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" is not null"), "Pass: test \"hello\" is not null", "hello"),
+//            ValidationError(dataTrace().tag("assertion" to "test null is not null"), "Fail: test null is not null", null),
+//        )
+//    }
+//
+//    @Test
+//    fun `test assertInstanceOf`() {
+//        val assertions = Assertions(dataTrace())
+//
+//        assertions.assertInstanceOf<String>("test \"hello\" is a String", "hello")
+//        assertions.assertInstanceOf<String>("test 1 is a String", 1)
+//        assertions.assertInstanceOf<String>("test null is a String", null)
+//        assertions.assertInstanceOf<String?>("test null is a nullable String", null)
+//
+//        assertThat(assertions.results).containsExactly(
+//            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" is a String"), "Pass: test \"hello\" is a String", "hello is a kotlin.String"),
+//            ValidationError(dataTrace().tag("assertion" to "test 1 is a String"), "Fail: test 1 is a String", "1 is a kotlin.Int"),
+//            ValidationError(dataTrace().tag("assertion" to "test null is a String"), "Fail: test null is a String", "null is a null"),
+//            ValidationInfo(dataTrace().tag("assertion" to "test null is a nullable String"), "Pass: test null is a nullable String", "null is a null"),
+//        )
+//    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -559,141 +559,185 @@ internal class AssertThatTest {
         }
     }
 
-//
-//    @Test
-//    fun `test assertContains`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertContains("test 1 in [1,2,3]", listOf(1,2,3), 1)
-//        assertions.assertContains("test 1 in []", emptyList<Int>(), 1)
-//        assertions.assertContains("test null in [1,2,3]", listOf(1,2,3), null)
-//        assertions.assertContains("test 1 in null", null, 1)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationInfo(dataTrace().tag("assertion" to "test 1 in [1,2,3]"), "Pass: test 1 in [1,2,3]", "1 in [1, 2, 3]"),
-//            ValidationError(dataTrace().tag("assertion" to "test 1 in []"), "Fail: test 1 in []", "1 in []"),
-//            ValidationError(dataTrace().tag("assertion" to "test null in [1,2,3]"), "Fail: test null in [1,2,3]", "null in [1, 2, 3]"),
-//            ValidationError(dataTrace().tag("assertion" to "test 1 in null"), "Fail: test 1 in null", "1 in null"),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertNotContains`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertNotContains("test 1 !in [1,2,3]", listOf(1,2,3), 1)
-//        assertions.assertNotContains("test 1 !in []", emptyList<Int>(), 1)
-//        assertions.assertNotContains("test null !in [1,2,3]", listOf(1,2,3), null)
-//        assertions.assertNotContains("test 1 !in null", null, 1)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationError(dataTrace().tag("assertion" to "test 1 !in [1,2,3]"), "Fail: test 1 !in [1,2,3]", "1 not in [1, 2, 3]"),
-//            ValidationInfo(dataTrace().tag("assertion" to "test 1 !in []"), "Pass: test 1 !in []", "1 not in []"),
-//            ValidationInfo(dataTrace().tag("assertion" to "test null !in [1,2,3]"), "Pass: test null !in [1,2,3]", "null not in [1, 2, 3]"),
-//            ValidationError(dataTrace().tag("assertion" to "test 1 !in null"), "Fail: test 1 !in null", "1 not in null"),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertEmpty`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertEmpty("test [1,2,3] is empty", listOf(1,2,3))
-//        assertions.assertEmpty("test [] is empty", emptyList<Int>())
-//        assertions.assertEmpty("test null is empty", null)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationError(dataTrace().tag("assertion" to "test [1,2,3] is empty"), "Fail: test [1,2,3] is empty", listOf(1, 2, 3)),
-//            ValidationInfo(dataTrace().tag("assertion" to "test [] is empty"), "Pass: test [] is empty", emptyList<Int>()),
-//            ValidationError(dataTrace().tag("assertion" to "test null is empty"), "Fail: test null is empty", null),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertNullOrEmpty`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertNullOrEmpty("test [1,2,3] is null or empty", listOf(1,2,3))
-//        assertions.assertNullOrEmpty("test [] is null or empty", emptyList<Int>())
-//        assertions.assertNullOrEmpty("test null is null or empty", null)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationError(dataTrace().tag("assertion" to "test [1,2,3] is null or empty"), "Fail: test [1,2,3] is null or empty", listOf(1, 2, 3)),
-//            ValidationInfo(dataTrace().tag("assertion" to "test [] is null or empty"), "Pass: test [] is null or empty", emptyList<Int>()),
-//            ValidationInfo(dataTrace().tag("assertion" to "test null is null or empty"), "Pass: test null is null or empty", null),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertNotEmpty`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertNotEmpty("test [1,2,3] is not empty", listOf(1,2,3))
-//        assertions.assertNotEmpty("test [] is not empty", emptyList<Int>())
-//        assertions.assertNotEmpty("test null is not empty", null)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationInfo(dataTrace().tag("assertion" to "test [1,2,3] is not empty"), "Pass: test [1,2,3] is not empty", listOf(1, 2, 3)),
-//            ValidationError(dataTrace().tag("assertion" to "test [] is not empty"), "Fail: test [] is not empty", emptyList<Int>()),
-//            ValidationError(dataTrace().tag("assertion" to "test null is not empty"), "Fail: test null is not empty", null),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertSizeEquals`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertSizeEquals("test [1,2,3] is length 3", listOf(1,2,3), 3)
-//        assertions.assertSizeEquals("test [] is length 3", emptyList<Int>(), 3)
-//        assertions.assertSizeEquals("test null is length 3", null, 3)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationInfo(dataTrace().tag("assertion" to "test [1,2,3] is length 3"), "Pass: test [1,2,3] is length 3", "3 = size([1, 2, 3])"),
-//            ValidationError(dataTrace().tag("assertion" to "test [] is length 3"), "Fail: test [] is length 3", "3 = size([])"),
-//            ValidationError(dataTrace().tag("assertion" to "test null is length 3"), "Fail: test null is length 3", "3 = size(null)"),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertNull`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertNull("test \"hello\" is null", "hello")
-//        assertions.assertNull("test null is null", null)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationError(dataTrace().tag("assertion" to "test \"hello\" is null"), "Fail: test \"hello\" is null", "hello"),
-//            ValidationInfo(dataTrace().tag("assertion" to "test null is null"), "Pass: test null is null", null),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertNotNull`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertNotNull("test \"hello\" is not null", "hello")
-//        assertions.assertNotNull("test null is not null", null)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" is not null"), "Pass: test \"hello\" is not null", "hello"),
-//            ValidationError(dataTrace().tag("assertion" to "test null is not null"), "Fail: test null is not null", null),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertInstanceOf`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertInstanceOf<String>("test \"hello\" is a String", "hello")
-//        assertions.assertInstanceOf<String>("test 1 is a String", 1)
-//        assertions.assertInstanceOf<String>("test null is a String", null)
-//        assertions.assertInstanceOf<String?>("test null is a nullable String", null)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" is a String"), "Pass: test \"hello\" is a String", "hello is a kotlin.String"),
-//            ValidationError(dataTrace().tag("assertion" to "test 1 is a String"), "Fail: test 1 is a String", "1 is a kotlin.Int"),
-//            ValidationError(dataTrace().tag("assertion" to "test null is a String"), "Fail: test null is a String", "null is a null"),
-//            ValidationInfo(dataTrace().tag("assertion" to "test null is a nullable String"), "Pass: test null is a nullable String", "null is a null"),
-//        )
-//    }
+    @Test
+    fun `test assertThat Collection contains`() {
+        val data = dataOf(
+            "value" to listOf(1, 2, 3),
+            "valueEmpty" to emptyList<Int>(),
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<List<Int>>(data, "value").contains(1)
+            assertThat<List<Int>>(data, "valueEmpty").contains(1)
+            assertThat<List<Int>>(data, "value").contains(null)
+            assertThat<List<Int>?>(data, "valueNull").contains(1)
+            assertThat<List<Int>>(data, "valueNull").contains(1)
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] contains 1"), "Pass: data[value] contains 1", "1 in [1, 2, 3]"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueEmpty] contains 1"), "Fail: data[valueEmpty] contains 1", "1 in []"),
+                ValidationError(dataTrace().tag("assertion" to "data[value] contains null"), "Fail: data[value] contains null", "null in [1, 2, 3]"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] contains 1"), "Fail: data[valueNull] contains 1", "1 in null"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] contains 1"), "Fail: data[valueNull] contains 1", "1 in null"),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat Collection notContains`() {
+        val data = dataOf(
+            "value" to listOf(1, 2, 3),
+            "valueEmpty" to emptyList<Int>(),
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<List<Int>>(data, "value").notContains(1)
+            assertThat<List<Int>>(data, "valueEmpty").notContains(1)
+            assertThat<List<Int>>(data, "value").notContains(null)
+            assertThat<List<Int>?>(data, "valueNull").notContains(1)
+            assertThat<List<Int>>(data, "valueNull").notContains(1)
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationError(dataTrace().tag("assertion" to "data[value] not contains 1"), "Fail: data[value] not contains 1", "1 not in [1, 2, 3]"),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueEmpty] not contains 1"), "Pass: data[valueEmpty] not contains 1", "1 not in []"),
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] not contains null"), "Pass: data[value] not contains null", "null not in [1, 2, 3]"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] not contains 1"), "Fail: data[valueNull] not contains 1", "1 not in null"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] not contains 1"), "Fail: data[valueNull] not contains 1", "1 not in null"),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat Collection isEmpty`() {
+        val data = dataOf(
+            "value" to listOf(1, 2, 3),
+            "valueEmpty" to emptyList<Int>(),
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<List<Int>>(data, "value").isEmpty()
+            assertThat<List<Int>>(data, "valueEmpty").isEmpty()
+            assertThat<List<Int>?>(data, "valueNull").isEmpty()
+            assertThat<List<Int>>(data, "valueNull").isEmpty()
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationError(dataTrace().tag("assertion" to "data[value] is empty"), "Fail: data[value] is empty", listOf(1, 2, 3)),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueEmpty] is empty"), "Pass: data[valueEmpty] is empty", emptyList<Int>()),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is empty"), "Fail: data[valueNull] is empty", null),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is empty"), "Fail: data[valueNull] is empty", null),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat Collection isNullOrEmpty`() {
+        val data = dataOf(
+            "value" to listOf(1, 2, 3),
+            "valueEmpty" to emptyList<Int>(),
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<List<Int>>(data, "value").isNullOrEmpty()
+            assertThat<List<Int>>(data, "valueEmpty").isNullOrEmpty()
+            assertThat<List<Int>?>(data, "valueNull").isNullOrEmpty()
+            assertThat<List<Int>>(data, "valueNull").isNullOrEmpty()
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationError(dataTrace().tag("assertion" to "data[value] is null or empty"), "Fail: data[value] is null or empty", listOf(1, 2, 3)),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueEmpty] is null or empty"), "Pass: data[valueEmpty] is null or empty", emptyList<Int>()),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is null or empty"), "Pass: data[valueNull] is null or empty", null),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is null or empty"), "Fail: data[valueNull] is null or empty", null),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat Collection isNotEmpty`() {
+        val data = dataOf(
+            "value" to listOf(1, 2, 3),
+            "valueEmpty" to emptyList<Int>(),
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<List<Int>>(data, "value").isNotEmpty()
+            assertThat<List<Int>>(data, "valueEmpty").isNotEmpty()
+            assertThat<List<Int>?>(data, "valueNull").isNotEmpty()
+            assertThat<List<Int>>(data, "valueNull").isNotEmpty()
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is not empty"), "Pass: data[value] is not empty", listOf(1, 2, 3)),
+                ValidationError(dataTrace().tag("assertion" to "data[valueEmpty] is not empty"), "Fail: data[valueEmpty] is not empty", emptyList<Int>()),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is not empty"), "Fail: data[valueNull] is not empty", null),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is not empty"), "Fail: data[valueNull] is not empty", null),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat Collection isSizeEquals`() {
+        val data = dataOf(
+            "value" to listOf(1, 2, 3),
+            "valueEmpty" to emptyList<Int>(),
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<List<Int>>(data, "value").isSizeEquals(3)
+            assertThat<List<Int>>(data, "valueEmpty").isSizeEquals(3)
+            assertThat<List<Int>?>(data, "valueNull").isSizeEquals(3)
+            assertThat<List<Int>>(data, "valueNull").isSizeEquals(3)
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is size equal to 3"), "Pass: data[value] is size equal to 3", "3 = size([1, 2, 3])"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueEmpty] is size equal to 3"), "Fail: data[valueEmpty] is size equal to 3", "3 = size([])"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is size equal to 3"), "Fail: data[valueNull] is size equal to 3", "3 = size(null)"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is size equal to 3"), "Fail: data[valueNull] is size equal to 3", "3 = size(null)"),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat isNull`() {
+        val data = dataOf(
+            "value" to "Hello World",
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<String>(data, "value").isNull()
+            assertThat<String?>(data, "valueNull").isNull()
+            assertThat<String>(data, "valueNull").isNull()
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationError(dataTrace().tag("assertion" to "data[value] is null"), "Fail: data[value] is null", "Hello World"),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is null"), "Pass: data[valueNull] is null", null),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is null"), "Fail: data[valueNull] is null", null),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat isNotNull`() {
+        val data = dataOf(
+            "value" to "Hello World",
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<String>(data, "value").isNotNull()
+            assertThat<String?>(data, "valueNull").isNotNull()
+            assertThat<String>(data, "valueNull").isNotNull()
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is not null"), "Pass: data[value] is not null", "Hello World"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is not null"), "Fail: data[valueNull] is not null", null),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is not null"), "Fail: data[valueNull] is not null", null),
+            )
+        }
+    }
 }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -44,7 +44,6 @@ internal class AssertThatTest {
         }
     }
 
-
     @Test
     fun `test assertThat Boolean isTrue`() {
         val data = dataOf(

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -84,10 +84,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isTrue() }
-            assertThat(data).hasAttribute("value2"){ it.isA<Boolean>().isTrue() }
-            assertThat(data).hasAttribute("value3"){ it.isA<Boolean>().isTrue() }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Boolean>().isTrue() }
+            assertThat(data).hasAttribute("value1") { it.isA<Boolean>().isTrue() }
+            assertThat(data).hasAttribute("value2") { it.isA<Boolean>().isTrue() }
+            assertThat(data).hasAttribute("value3") { it.isA<Boolean>().isTrue() }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Boolean>().isTrue() }
 
             val results = this.results.toList()
 
@@ -109,10 +109,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isFalse() }
-            assertThat(data).hasAttribute("value2"){ it.isA<Boolean>().isFalse() }
-            assertThat(data).hasAttribute("value3"){ it.isA<Boolean>().isFalse() }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Boolean>().isTrue() }
+            assertThat(data).hasAttribute("value1") { it.isA<Boolean>().isFalse() }
+            assertThat(data).hasAttribute("value2") { it.isA<Boolean>().isFalse() }
+            assertThat(data).hasAttribute("value3") { it.isA<Boolean>().isFalse() }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Boolean>().isTrue() }
 
             val results = this.results.toList()
 
@@ -133,12 +133,12 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isEqualTo(true) }
-            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isEqualTo(false) }
-            assertThat(data).hasAttribute("value2"){ it.isA<String>().isEqualTo("Hello World") }
-            assertThat(data).hasAttribute("value2"){ it.isA<String>().isEqualTo("Goodbye") }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<String?>().isEqualTo("Hi") }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<String>().isEqualTo("Hi") }
+            assertThat(data).hasAttribute("value1") { it.isA<Boolean>().isEqualTo(true) }
+            assertThat(data).hasAttribute("value1") { it.isA<Boolean>().isEqualTo(false) }
+            assertThat(data).hasAttribute("value2") { it.isA<String>().isEqualTo("Hello World") }
+            assertThat(data).hasAttribute("value2") { it.isA<String>().isEqualTo("Goodbye") }
+            assertThat(data).hasAttribute("valueNull") { it.isA<String?>().isEqualTo("Hi") }
+            assertThat(data).hasAttribute("valueNull") { it.isA<String>().isEqualTo("Hi") }
 
             val results = this.results.toList()
 
@@ -161,10 +161,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isNotEqualTo(true) }
-            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isNotEqualTo(false) }
-            assertThat(data).hasAttribute("value2"){ it.isA<String>().isNotEqualTo("Hello World") }
-            assertThat(data).hasAttribute("value2"){ it.isA<String>().isNotEqualTo("Goodbye") }
+            assertThat(data).hasAttribute("value1") { it.isA<Boolean>().isNotEqualTo(true) }
+            assertThat(data).hasAttribute("value1") { it.isA<Boolean>().isNotEqualTo(false) }
+            assertThat(data).hasAttribute("value2") { it.isA<String>().isNotEqualTo("Hello World") }
+            assertThat(data).hasAttribute("value2") { it.isA<String>().isNotEqualTo("Goodbye") }
 
             val results = this.results.toList()
 
@@ -184,9 +184,9 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThan(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThan(2) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Int>().isLessThan(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isLessThan(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isLessThan(2) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Int>().isLessThan(1) }
 
             val results = this.results.toList()
 
@@ -206,9 +206,9 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThan(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThan(2) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Long>().isLessThan(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isLessThan(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isLessThan(2) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Long>().isLessThan(1) }
 
             val results = this.results.toList()
 
@@ -228,9 +228,9 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThan(1.0f) }
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThan(2.0f) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Float>().isLessThan(1.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isLessThan(1.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isLessThan(2.0f) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Float>().isLessThan(1.0f) }
 
             val results = this.results.toList()
 
@@ -250,9 +250,9 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThan(1.0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThan(2.0) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Double>().isLessThan(1.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isLessThan(1.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isLessThan(2.0) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Double>().isLessThan(1.0) }
 
             val results = this.results.toList()
 
@@ -271,10 +271,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThanEquals(0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThanEquals(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThanEquals(2) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Int>().isLessThanEquals(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isLessThanEquals(0) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isLessThanEquals(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isLessThanEquals(2) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Int>().isLessThanEquals(1) }
 
             val results = this.results.toList()
 
@@ -294,10 +294,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThanEquals(0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThanEquals(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThanEquals(2) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Long>().isLessThanEquals(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isLessThanEquals(0) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isLessThanEquals(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isLessThanEquals(2) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Long>().isLessThanEquals(1) }
 
             val results = this.results.toList()
 
@@ -317,10 +317,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThanEquals(0.0f) }
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThanEquals(1.0f) }
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThanEquals(2.0f) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Float>().isLessThanEquals(1.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isLessThanEquals(0.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isLessThanEquals(1.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isLessThanEquals(2.0f) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Float>().isLessThanEquals(1.0f) }
 
             val results = this.results.toList()
 
@@ -340,10 +340,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThanEquals(0.0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThanEquals(1.0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThanEquals(2.0) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Double>().isLessThanEquals(1.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isLessThanEquals(0.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isLessThanEquals(1.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isLessThanEquals(2.0) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Double>().isLessThanEquals(1.0) }
 
             val results = this.results.toList()
 
@@ -363,10 +363,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThan(0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThan(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThan(2) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Int>().isGreaterThan(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isGreaterThan(0) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isGreaterThan(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isGreaterThan(2) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Int>().isGreaterThan(1) }
 
             val results = this.results.toList()
 
@@ -386,10 +386,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThan(0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThan(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThan(2) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Long>().isGreaterThan(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isGreaterThan(0) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isGreaterThan(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isGreaterThan(2) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Long>().isGreaterThan(1) }
 
             val results = this.results.toList()
 
@@ -409,10 +409,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThan(0.0f) }
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThan(1.0f) }
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThan(2.0f) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Float>().isGreaterThan(1.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isGreaterThan(0.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isGreaterThan(1.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isGreaterThan(2.0f) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Float>().isGreaterThan(1.0f) }
 
             val results = this.results.toList()
 
@@ -432,10 +432,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThan(0.0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThan(1.0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThan(2.0) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Double>().isGreaterThan(1.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isGreaterThan(0.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isGreaterThan(1.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isGreaterThan(2.0) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Double>().isGreaterThan(1.0) }
 
             val results = this.results.toList()
 
@@ -455,10 +455,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThanEquals(0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThanEquals(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThanEquals(2) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Int>().isGreaterThanEquals(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isGreaterThanEquals(0) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isGreaterThanEquals(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Int>().isGreaterThanEquals(2) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Int>().isGreaterThanEquals(1) }
 
             val results = this.results.toList()
 
@@ -478,10 +478,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThanEquals(0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThanEquals(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThanEquals(2) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Long>().isGreaterThanEquals(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isGreaterThanEquals(0) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isGreaterThanEquals(1) }
+            assertThat(data).hasAttribute("value") { it.isA<Long>().isGreaterThanEquals(2) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Long>().isGreaterThanEquals(1) }
 
             val results = this.results.toList()
 
@@ -501,10 +501,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThanEquals(0.0f) }
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThanEquals(1.0f) }
-            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThanEquals(2.0f) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Float>().isGreaterThanEquals(1.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isGreaterThanEquals(0.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isGreaterThanEquals(1.0f) }
+            assertThat(data).hasAttribute("value") { it.isA<Float>().isGreaterThanEquals(2.0f) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Float>().isGreaterThanEquals(1.0f) }
 
             val results = this.results.toList()
 
@@ -524,10 +524,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThanEquals(0.0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThanEquals(1.0) }
-            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThanEquals(2.0) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<Double>().isGreaterThanEquals(1.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isGreaterThanEquals(0.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isGreaterThanEquals(1.0) }
+            assertThat(data).hasAttribute("value") { it.isA<Double>().isGreaterThanEquals(2.0) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<Double>().isGreaterThanEquals(1.0) }
 
             val results = this.results.toList()
 
@@ -548,10 +548,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().contains(1) }
-            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().contains(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().contains(null) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().contains(1) }
+            assertThat(data).hasAttribute("value") { it.isA<List<Int>>().contains(1) }
+            assertThat(data).hasAttribute("valueEmpty") { it.isA<List<Int>>().contains(1) }
+            assertThat(data).hasAttribute("value") { it.isA<List<Int>>().contains(null) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<List<Int>>().contains(1) }
 
             val results = this.results.toList()
 
@@ -574,10 +574,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isOneOf(collection) }
-            assertThat(data).hasAttribute("value"){ it.isOneOf(emptyCollection) }
-            assertThat(data).hasAttribute("valueNull"){ it.isOneOf(collection) }
-            assertThat(data).hasAttribute("valueNull"){ it.isOneOf(collectionWithNull) }
+            assertThat(data).hasAttribute("value") { it.isOneOf(collection) }
+            assertThat(data).hasAttribute("value") { it.isOneOf(emptyCollection) }
+            assertThat(data).hasAttribute("valueNull") { it.isOneOf(collection) }
+            assertThat(data).hasAttribute("valueNull") { it.isOneOf(collectionWithNull) }
 
             val results = this.results.toList()
 
@@ -598,10 +598,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().notContains(1) }
-            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().notContains(1) }
-            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().notContains(null) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().notContains(1) }
+            assertThat(data).hasAttribute("value") { it.isA<List<Int>>().notContains(1) }
+            assertThat(data).hasAttribute("valueEmpty") { it.isA<List<Int>>().notContains(1) }
+            assertThat(data).hasAttribute("value") { it.isA<List<Int>>().notContains(null) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<List<Int>>().notContains(1) }
 
             val results = this.results.toList()
 
@@ -622,9 +622,9 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().isEmpty() }
-            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().isEmpty() }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().isEmpty() }
+            assertThat(data).hasAttribute("value") { it.isA<List<Int>>().isEmpty() }
+            assertThat(data).hasAttribute("valueEmpty") { it.isA<List<Int>>().isEmpty() }
+            assertThat(data).hasAttribute("valueNull") { it.isA<List<Int>>().isEmpty() }
 
             val results = this.results.toList()
 
@@ -644,9 +644,9 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<List<Int>?>().isNullOrEmpty() }
-            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>?>().isNullOrEmpty() }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>?>().isNullOrEmpty() }
+            assertThat(data).hasAttribute("value") { it.isA<List<Int>?>().isNullOrEmpty() }
+            assertThat(data).hasAttribute("valueEmpty") { it.isA<List<Int>?>().isNullOrEmpty() }
+            assertThat(data).hasAttribute("valueNull") { it.isA<List<Int>?>().isNullOrEmpty() }
 
             val results = this.results.toList()
 
@@ -666,10 +666,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().isNotEmpty() }
-            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().isNotEmpty() }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>?>().isNotEmpty() }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().isNotEmpty() }
+            assertThat(data).hasAttribute("value") { it.isA<List<Int>>().isNotEmpty() }
+            assertThat(data).hasAttribute("valueEmpty") { it.isA<List<Int>>().isNotEmpty() }
+            assertThat(data).hasAttribute("valueNull") { it.isA<List<Int>?>().isNotEmpty() }
+            assertThat(data).hasAttribute("valueNull") { it.isA<List<Int>>().isNotEmpty() }
 
             val results = this.results.toList()
 
@@ -690,10 +690,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().isSizeEquals(3) }
-            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().isSizeEquals(3) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>?>().isSizeEquals(3) }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().isSizeEquals(3) }
+            assertThat(data).hasAttribute("value") { it.isA<List<Int>>().isSizeEquals(3) }
+            assertThat(data).hasAttribute("valueEmpty") { it.isA<List<Int>>().isSizeEquals(3) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<List<Int>?>().isSizeEquals(3) }
+            assertThat(data).hasAttribute("valueNull") { it.isA<List<Int>>().isSizeEquals(3) }
 
             val results = this.results.toList()
 
@@ -713,8 +713,8 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isNull() }
-            assertThat(data).hasAttribute("valueNull"){ it.isNull() }
+            assertThat(data).hasAttribute("value") { it.isNull() }
+            assertThat(data).hasAttribute("valueNull") { it.isNull() }
 
             val results = this.results.toList()
 
@@ -732,12 +732,12 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){
+            assertThat(data).hasAttribute("value") {
                 it.isNullOr {
                     it.isEqualTo("Hello World")
                 }
             }
-            assertThat(data).hasAttribute("valueNull"){
+            assertThat(data).hasAttribute("valueNull") {
                 it.isNullOr {
                     it.isEqualTo("Hello World")
                 }
@@ -759,8 +759,8 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("value"){ it.isNotNull() }
-            assertThat(data).hasAttribute("valueNull"){ it.isNotNull() }
+            assertThat(data).hasAttribute("value") { it.isNotNull() }
+            assertThat(data).hasAttribute("valueNull") { it.isNotNull() }
 
             val results = this.results.toList()
 
@@ -778,10 +778,10 @@ internal class AssertThatTest {
             "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat(data).hasAttribute("valueStr"){ it.isA<String>() }
-            assertThat(data).hasAttribute("valueStr"){ it.isA<Int>() }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<String>() }
-            assertThat(data).hasAttribute("valueNull"){ it.isA<String?>() }
+            assertThat(data).hasAttribute("valueStr") { it.isA<String>() }
+            assertThat(data).hasAttribute("valueStr") { it.isA<Int>() }
+            assertThat(data).hasAttribute("valueNull") { it.isA<String>() }
+            assertThat(data).hasAttribute("valueNull") { it.isA<String?>() }
 
             val results = this.results.toList()
 
@@ -804,19 +804,19 @@ internal class AssertThatTest {
             assertThat(data).hasAttribute("value") { attr ->
                 attr.or(
                     { it.isNull() },
-                    { it.isEqualTo("Hello World")}
+                    { it.isEqualTo("Hello World") }
                 )
             }
-            assertThat(data).hasAttribute("valueNull"){ attr ->
+            assertThat(data).hasAttribute("valueNull") { attr ->
                 attr.or(
                     { it.isNull() },
-                    { it.isEqualTo("Hello World")}
+                    { it.isEqualTo("Hello World") }
                 )
             }
             assertThat(data).hasAttribute("value") { attr ->
                 attr.or(
                     { it.isNull() },
-                    { it.isEqualTo("Good Bye")}
+                    { it.isEqualTo("Good Bye") }
                 )
             }
 

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -802,21 +802,21 @@ internal class AssertThatTest {
         )
         with(Assertions(dataTrace())) {
             assertThat(data).hasAttribute("value") { attr ->
-                attr.or(
-                    { it.isNull() },
-                    { it.isEqualTo("Hello World") }
+                or(
+                    { attr.isNull() },
+                    { attr.isEqualTo("Hello World") }
                 )
             }
             assertThat(data).hasAttribute("valueNull") { attr ->
-                attr.or(
-                    { it.isNull() },
-                    { it.isEqualTo("Hello World") }
+                or(
+                    { attr.isNull() },
+                    { attr.isEqualTo("Hello World") }
                 )
             }
             assertThat(data).hasAttribute("value") { attr ->
-                attr.or(
-                    { it.isNull() },
-                    { it.isEqualTo("Good Bye") }
+                or(
+                    { attr.isNull() },
+                    { attr.isEqualTo("Good Bye") },
                 )
             }
 

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -12,15 +12,43 @@ import org.assertj.core.api.Assertions.assertThat as junitAssertThat
 internal class AssertThatTest {
 
     @Test
+    fun `test assertThat Data has attribute`() {
+        val data = dataOf(
+            "value" to 1,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat(data)
+                .hasAttribute("value") { attr ->
+                    attr.isA<Int?>()
+                        .isNotNull()
+                }
+                .hasAttribute("noValue") { attr ->
+                    attr.isA<Int?>()
+                        .isNotNull()
+                }
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] exists"), "Pass: data[value] exists", data),
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is a kotlin.Int"), "Pass: data[value] is a kotlin.Int", 1),
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is not null"), "Pass: data[value] is not null", 1),
+                ValidationError(dataTrace().tag("assertion" to "data[noValue] exists"), "Fail: data[noValue] exists", data),
+                ValidationError(dataTrace().tag("assertion" to "data[noValue] is a kotlin.Int"), "Fail: data[noValue] is a kotlin.Int", null),
+                ValidationError(dataTrace().tag("assertion" to "data[noValue] is not null"), "Fail: data[noValue] is not null", null),
+            )
+        }
+    }
+
+    @Test
     fun `test assertThat with typed value returns AssertThatValue`() {
         with(Assertions(dataTrace())) {
-            val assertThatValue = assertThat("hello world").isNotNull()
+            val assertThatValue = assertThat("hello world").isEqualTo("hello world")
             junitAssertThat(assertThatValue.actual).isEqualTo("hello world")
 
             val results = this.results.toList()
 
             junitAssertThat(results).contains(
-                ValidationInfo(dataTrace().tag("assertion" to "is not null"), "Pass: is not null", "hello world"),
+                ValidationInfo(dataTrace().tag("assertion" to "is equal to hello world"), "Pass: is equal to hello world", "hello world == hello world"),
             )
         }
     }
@@ -48,52 +76,18 @@ internal class AssertThatTest {
     }
 
     @Test
-    fun `test assertThat validates types`() {
-        val data = dataOf(
-            "value" to true,
-        )
-        with(Assertions(dataTrace())) {
-            assertThat<Boolean>(data, "value")
-            assertThat<String>(data, "value")
-
-            val results = this.results.toList()
-
-            junitAssertThat(results).contains(
-                ValidationInfo(dataTrace().tag("assertion" to "assertThat<kotlin.Boolean>(data[value])"), "Pass: assertThat<kotlin.Boolean>(data[value])", "true is a kotlin.Boolean"),
-                ValidationError(dataTrace().tag("assertion" to "assertThat<kotlin.String>(data[value])"), "Fail: assertThat<kotlin.String>(data[value])", "true is a kotlin.Boolean"),
-            )
-        }
-    }
-
-    @Test
-    fun `test assertThat validate instance of nullable type`() {
-        val data = dataOf(
-            "value" to null,
-        )
-        with(Assertions(dataTrace())) {
-            assertThat<Boolean?>(data, "value")
-            assertThat<Boolean>(data, "value")
-
-            junitAssertThat(this.results.toList()).contains(
-                ValidationInfo(dataTrace().tag("assertion" to "assertThat<kotlin.Boolean>(data[value])"), "Pass: assertThat<kotlin.Boolean>(data[value])", "null is a kotlin.Boolean?"),
-                ValidationError(dataTrace().tag("assertion" to "assertThat<kotlin.Boolean>(data[value])"), "Fail: assertThat<kotlin.Boolean>(data[value])", "null is a kotlin.Boolean?"),
-            )
-        }
-    }
-
-    @Test
     fun `test assertThat Boolean isTrue`() {
         val data = dataOf(
             "value1" to true,
             "value2" to false,
-            "value3" to "Hello World"
+            "value3" to "Hello World",
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Boolean>(data, "value1").isTrue()
-            assertThat<Boolean>(data, "value2").isTrue()
-            assertThat<Boolean>(data, "value3").isTrue()
-            assertThat<Boolean?>(data, "valueNull").isTrue()
-            assertThat<Boolean>(data, "valueNull").isTrue()
+            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isTrue() }
+            assertThat(data).hasAttribute("value2"){ it.isA<Boolean>().isTrue() }
+            assertThat(data).hasAttribute("value3"){ it.isA<Boolean>().isTrue() }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Boolean>().isTrue() }
 
             val results = this.results.toList()
 
@@ -101,7 +95,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value1] is true"), "Pass: data[value1] is true", true),
                 ValidationError(dataTrace().tag("assertion" to "data[value2] is true"), "Fail: data[value2] is true", false),
                 ValidationError(dataTrace().tag("assertion" to "data[value3] is true"), "Fail: data[value3] is true", "Hello World"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is true"), "Fail: data[valueNull] is true", null),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is true"), "Fail: data[valueNull] is true", null),
             )
         }
@@ -112,14 +105,14 @@ internal class AssertThatTest {
         val data = dataOf(
             "value1" to true,
             "value2" to false,
-            "value3" to "Hello World"
+            "value3" to "Hello World",
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Boolean>(data, "value1").isFalse()
-            assertThat<Boolean>(data, "value2").isFalse()
-            assertThat<Boolean>(data, "value3").isFalse()
-            assertThat<Boolean?>(data, "valueNull").isTrue()
-            assertThat<Boolean>(data, "valueNull").isTrue()
+            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isFalse() }
+            assertThat(data).hasAttribute("value2"){ it.isA<Boolean>().isFalse() }
+            assertThat(data).hasAttribute("value3"){ it.isA<Boolean>().isFalse() }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Boolean>().isTrue() }
 
             val results = this.results.toList()
 
@@ -127,7 +120,6 @@ internal class AssertThatTest {
                 ValidationError(dataTrace().tag("assertion" to "data[value1] is false"), "Fail: data[value1] is false", true),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value2] is false"), "Pass: data[value2] is false", false),
                 ValidationError(dataTrace().tag("assertion" to "data[value3] is false"), "Fail: data[value3] is false", "Hello World"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is true"), "Fail: data[valueNull] is true", null),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is true"), "Fail: data[valueNull] is true", null),
             )
         }
@@ -137,15 +129,16 @@ internal class AssertThatTest {
     fun `test assertThat isEquals`() {
         val data = dataOf(
             "value1" to true,
-            "value2" to "Hello World"
+            "value2" to "Hello World",
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Boolean>(data, "value1").isEqualTo(true)
-            assertThat<Boolean>(data, "value1").isEqualTo(false)
-            assertThat<String>(data, "value2").isEqualTo("Hello World")
-            assertThat<String>(data, "value2").isEqualTo("Goodbye")
-            assertThat<String?>(data, "valueNull").isEqualTo("Hi")
-            assertThat<String>(data, "valueNull").isEqualTo("Hi")
+            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isEqualTo(true) }
+            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isEqualTo(false) }
+            assertThat(data).hasAttribute("value2"){ it.isA<String>().isEqualTo("Hello World") }
+            assertThat(data).hasAttribute("value2"){ it.isA<String>().isEqualTo("Goodbye") }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<String?>().isEqualTo("Hi") }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<String>().isEqualTo("Hi") }
 
             val results = this.results.toList()
 
@@ -164,13 +157,14 @@ internal class AssertThatTest {
     fun `test assertThat isNotEquals`() {
         val data = dataOf(
             "value1" to true,
-            "value2" to "Hello World"
+            "value2" to "Hello World",
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Boolean>(data, "value1").isNotEqualTo(true)
-            assertThat<Boolean>(data, "value1").isNotEqualTo(false)
-            assertThat<String>(data, "value2").isNotEqualTo("Hello World")
-            assertThat<String>(data, "value2").isNotEqualTo("Goodbye")
+            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isNotEqualTo(true) }
+            assertThat(data).hasAttribute("value1"){ it.isA<Boolean>().isNotEqualTo(false) }
+            assertThat(data).hasAttribute("value2"){ it.isA<String>().isNotEqualTo("Hello World") }
+            assertThat(data).hasAttribute("value2"){ it.isA<String>().isNotEqualTo("Goodbye") }
 
             val results = this.results.toList()
 
@@ -187,12 +181,12 @@ internal class AssertThatTest {
     fun `test assertThat Int isLessThan`() {
         val data = dataOf(
             "value" to 1,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Int>(data, "value").isLessThan(1)
-            assertThat<Int>(data, "value").isLessThan(2)
-            assertThat<Int?>(data, "valueNull").isLessThan(1)
-            assertThat<Int>(data, "valueNull").isLessThan(1)
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThan(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThan(2) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Int>().isLessThan(1) }
 
             val results = this.results.toList()
 
@@ -209,12 +203,12 @@ internal class AssertThatTest {
     fun `test assertThat Long isLessThan`() {
         val data = dataOf(
             "value" to 1L,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Long>(data, "value").isLessThan(1)
-            assertThat<Long>(data, "value").isLessThan(2)
-            assertThat<Long?>(data, "valueNull").isLessThan(1)
-            assertThat<Long>(data, "valueNull").isLessThan(1)
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThan(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThan(2) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Long>().isLessThan(1) }
 
             val results = this.results.toList()
 
@@ -231,12 +225,12 @@ internal class AssertThatTest {
     fun `test assertThat Float isLessThan`() {
         val data = dataOf(
             "value" to 1.0f,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Float>(data, "value").isLessThan(1.0f)
-            assertThat<Float>(data, "value").isLessThan(2.0f)
-            assertThat<Float?>(data, "valueNull").isLessThan(1.0f)
-            assertThat<Float>(data, "valueNull").isLessThan(1.0f)
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThan(1.0f) }
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThan(2.0f) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Float>().isLessThan(1.0f) }
 
             val results = this.results.toList()
 
@@ -253,19 +247,18 @@ internal class AssertThatTest {
     fun `test assertThat Double isLessThan`() {
         val data = dataOf(
             "value" to 1.0,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Double>(data, "value").isLessThan(1.0)
-            assertThat<Double>(data, "value").isLessThan(2.0)
-            assertThat<Double?>(data, "valueNull").isLessThan(1.0)
-            assertThat<Double>(data, "valueNull").isLessThan(1.0)
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThan(1.0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThan(2.0) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Double>().isLessThan(1.0) }
 
             val results = this.results.toList()
 
             junitAssertThat(results).contains(
                 ValidationError(dataTrace().tag("assertion" to "data[value] is less than 1.0"), "Fail: data[value] is less than 1.0", "1.0 < 1.0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than 2.0"), "Pass: data[value] is less than 2.0", "1.0 < 2.0"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than 1.0"), "Fail: data[valueNull] is less than 1.0", "null < 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than 1.0"), "Fail: data[valueNull] is less than 1.0", "null < 1.0"),
             )
         }
@@ -275,13 +268,13 @@ internal class AssertThatTest {
     fun `test assertThat Int isLessThanEquals`() {
         val data = dataOf(
             "value" to 1,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Int>(data, "value").isLessThanEquals(0)
-            assertThat<Int>(data, "value").isLessThanEquals(1)
-            assertThat<Int>(data, "value").isLessThanEquals(2)
-            assertThat<Int?>(data, "valueNull").isLessThanEquals(1)
-            assertThat<Int>(data, "valueNull").isLessThanEquals(1)
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThanEquals(0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThanEquals(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isLessThanEquals(2) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Int>().isLessThanEquals(1) }
 
             val results = this.results.toList()
 
@@ -289,7 +282,6 @@ internal class AssertThatTest {
                 ValidationError(dataTrace().tag("assertion" to "data[value] is less than equals 0"), "Fail: data[value] is less than equals 0", "1 <= 0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than equals 1"), "Pass: data[value] is less than equals 1", "1 <= 1"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than equals 2"), "Pass: data[value] is less than equals 2", "1 <= 2"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than equals 1"), "Fail: data[valueNull] is less than equals 1", "null <= 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than equals 1"), "Fail: data[valueNull] is less than equals 1", "null <= 1"),
             )
         }
@@ -299,13 +291,13 @@ internal class AssertThatTest {
     fun `test assertThat Long isLessThanEquals`() {
         val data = dataOf(
             "value" to 1L,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Long>(data, "value").isLessThanEquals(0)
-            assertThat<Long>(data, "value").isLessThanEquals(1)
-            assertThat<Long>(data, "value").isLessThanEquals(2)
-            assertThat<Long?>(data, "valueNull").isLessThanEquals(1)
-            assertThat<Long>(data, "valueNull").isLessThanEquals(1)
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThanEquals(0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThanEquals(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isLessThanEquals(2) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Long>().isLessThanEquals(1) }
 
             val results = this.results.toList()
 
@@ -313,7 +305,6 @@ internal class AssertThatTest {
                 ValidationError(dataTrace().tag("assertion" to "data[value] is less than equals 0"), "Fail: data[value] is less than equals 0", "1 <= 0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than equals 1"), "Pass: data[value] is less than equals 1", "1 <= 1"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than equals 2"), "Pass: data[value] is less than equals 2", "1 <= 2"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than equals 1"), "Fail: data[valueNull] is less than equals 1", "null <= 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than equals 1"), "Fail: data[valueNull] is less than equals 1", "null <= 1"),
             )
         }
@@ -323,13 +314,13 @@ internal class AssertThatTest {
     fun `test assertThat Float isLessThanEquals`() {
         val data = dataOf(
             "value" to 1.0f,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Float>(data, "value").isLessThanEquals(0.0f)
-            assertThat<Float>(data, "value").isLessThanEquals(1.0f)
-            assertThat<Float>(data, "value").isLessThanEquals(2.0f)
-            assertThat<Float?>(data, "valueNull").isLessThanEquals(1.0f)
-            assertThat<Float>(data, "valueNull").isLessThanEquals(1.0f)
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThanEquals(0.0f) }
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThanEquals(1.0f) }
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isLessThanEquals(2.0f) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Float>().isLessThanEquals(1.0f) }
 
             val results = this.results.toList()
 
@@ -337,7 +328,6 @@ internal class AssertThatTest {
                 ValidationError(dataTrace().tag("assertion" to "data[value] is less than equals 0.0"), "Fail: data[value] is less than equals 0.0", "1.0 <= 0.0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than equals 1.0"), "Pass: data[value] is less than equals 1.0", "1.0 <= 1.0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than equals 2.0"), "Pass: data[value] is less than equals 2.0", "1.0 <= 2.0"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than equals 1.0"), "Fail: data[valueNull] is less than equals 1.0", "null <= 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than equals 1.0"), "Fail: data[valueNull] is less than equals 1.0", "null <= 1.0"),
             )
         }
@@ -347,13 +337,13 @@ internal class AssertThatTest {
     fun `test assertThat Double isLessThanEquals`() {
         val data = dataOf(
             "value" to 1.0,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Double>(data, "value").isLessThanEquals(0.0)
-            assertThat<Double>(data, "value").isLessThanEquals(1.0)
-            assertThat<Double>(data, "value").isLessThanEquals(2.0)
-            assertThat<Double?>(data, "valueNull").isLessThanEquals(1.0)
-            assertThat<Double>(data, "valueNull").isLessThanEquals(1.0)
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThanEquals(0.0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThanEquals(1.0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isLessThanEquals(2.0) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Double>().isLessThanEquals(1.0) }
 
             val results = this.results.toList()
 
@@ -361,7 +351,6 @@ internal class AssertThatTest {
                 ValidationError(dataTrace().tag("assertion" to "data[value] is less than equals 0.0"), "Fail: data[value] is less than equals 0.0", "1.0 <= 0.0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than equals 1.0"), "Pass: data[value] is less than equals 1.0", "1.0 <= 1.0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than equals 2.0"), "Pass: data[value] is less than equals 2.0", "1.0 <= 2.0"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than equals 1.0"), "Fail: data[valueNull] is less than equals 1.0", "null <= 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than equals 1.0"), "Fail: data[valueNull] is less than equals 1.0", "null <= 1.0"),
             )
         }
@@ -371,13 +360,13 @@ internal class AssertThatTest {
     fun `test assertThat Int isGreaterThan`() {
         val data = dataOf(
             "value" to 1,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Int>(data, "value").isGreaterThan(0)
-            assertThat<Int>(data, "value").isGreaterThan(1)
-            assertThat<Int>(data, "value").isGreaterThan(2)
-            assertThat<Int?>(data, "valueNull").isGreaterThan(1)
-            assertThat<Int>(data, "valueNull").isGreaterThan(1)
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThan(0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThan(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThan(2) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Int>().isGreaterThan(1) }
 
             val results = this.results.toList()
 
@@ -385,7 +374,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than 0"), "Pass: data[value] is greater than 0", "1 > 0"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than 1"), "Fail: data[value] is greater than 1", "1 > 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than 2"), "Fail: data[value] is greater than 2", "1 > 2"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than 1"), "Fail: data[valueNull] is greater than 1", "null > 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than 1"), "Fail: data[valueNull] is greater than 1", "null > 1"),
             )
         }
@@ -395,13 +383,13 @@ internal class AssertThatTest {
     fun `test assertThat Long isGreaterThan`() {
         val data = dataOf(
             "value" to 1L,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Long>(data, "value").isGreaterThan(0)
-            assertThat<Long>(data, "value").isGreaterThan(1)
-            assertThat<Long>(data, "value").isGreaterThan(2)
-            assertThat<Long?>(data, "valueNull").isGreaterThan(1)
-            assertThat<Long>(data, "valueNull").isGreaterThan(1)
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThan(0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThan(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThan(2) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Long>().isGreaterThan(1) }
 
             val results = this.results.toList()
 
@@ -409,7 +397,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than 0"), "Pass: data[value] is greater than 0", "1 > 0"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than 1"), "Fail: data[value] is greater than 1", "1 > 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than 2"), "Fail: data[value] is greater than 2", "1 > 2"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than 1"), "Fail: data[valueNull] is greater than 1", "null > 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than 1"), "Fail: data[valueNull] is greater than 1", "null > 1"),
             )
         }
@@ -419,13 +406,13 @@ internal class AssertThatTest {
     fun `test assertThat Float isGreaterThan`() {
         val data = dataOf(
             "value" to 1.0f,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Float>(data, "value").isGreaterThan(0.0f)
-            assertThat<Float>(data, "value").isGreaterThan(1.0f)
-            assertThat<Float>(data, "value").isGreaterThan(2.0f)
-            assertThat<Float?>(data, "valueNull").isGreaterThan(1.0f)
-            assertThat<Float>(data, "valueNull").isGreaterThan(1.0f)
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThan(0.0f) }
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThan(1.0f) }
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThan(2.0f) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Float>().isGreaterThan(1.0f) }
 
             val results = this.results.toList()
 
@@ -433,7 +420,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than 0.0"), "Pass: data[value] is greater than 0.0", "1.0 > 0.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than 1.0"), "Fail: data[value] is greater than 1.0", "1.0 > 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than 2.0"), "Fail: data[value] is greater than 2.0", "1.0 > 2.0"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than 1.0"), "Fail: data[valueNull] is greater than 1.0", "null > 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than 1.0"), "Fail: data[valueNull] is greater than 1.0", "null > 1.0"),
             )
         }
@@ -443,13 +429,13 @@ internal class AssertThatTest {
     fun `test assertThat Double isGreaterThan`() {
         val data = dataOf(
             "value" to 1.0,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Double>(data, "value").isGreaterThan(0.0)
-            assertThat<Double>(data, "value").isGreaterThan(1.0)
-            assertThat<Double>(data, "value").isGreaterThan(2.0)
-            assertThat<Double?>(data, "valueNull").isGreaterThan(1.0)
-            assertThat<Double>(data, "valueNull").isGreaterThan(1.0)
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThan(0.0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThan(1.0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThan(2.0) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Double>().isGreaterThan(1.0) }
 
             val results = this.results.toList()
 
@@ -457,7 +443,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than 0.0"), "Pass: data[value] is greater than 0.0", "1.0 > 0.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than 1.0"), "Fail: data[value] is greater than 1.0", "1.0 > 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than 2.0"), "Fail: data[value] is greater than 2.0", "1.0 > 2.0"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than 1.0"), "Fail: data[valueNull] is greater than 1.0", "null > 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than 1.0"), "Fail: data[valueNull] is greater than 1.0", "null > 1.0"),
             )
         }
@@ -467,13 +452,13 @@ internal class AssertThatTest {
     fun `test assertThat Int isGreaterThanEquals`() {
         val data = dataOf(
             "value" to 1,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Int>(data, "value").isGreaterThanEquals(0)
-            assertThat<Int>(data, "value").isGreaterThanEquals(1)
-            assertThat<Int>(data, "value").isGreaterThanEquals(2)
-            assertThat<Int?>(data, "valueNull").isGreaterThanEquals(1)
-            assertThat<Int>(data, "valueNull").isGreaterThanEquals(1)
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThanEquals(0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThanEquals(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<Int>().isGreaterThanEquals(2) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Int>().isGreaterThanEquals(1) }
 
             val results = this.results.toList()
 
@@ -481,7 +466,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than equals 0"), "Pass: data[value] is greater than equals 0", "1 >= 0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than equals 1"), "Pass: data[value] is greater than equals 1", "1 >= 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than equals 2"), "Fail: data[value] is greater than equals 2", "1 >= 2"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than equals 1"), "Fail: data[valueNull] is greater than equals 1", "null >= 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than equals 1"), "Fail: data[valueNull] is greater than equals 1", "null >= 1"),
             )
         }
@@ -491,13 +475,13 @@ internal class AssertThatTest {
     fun `test assertThat Long isGreaterThanEquals`() {
         val data = dataOf(
             "value" to 1L,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Long>(data, "value").isGreaterThanEquals(0)
-            assertThat<Long>(data, "value").isGreaterThanEquals(1)
-            assertThat<Long>(data, "value").isGreaterThanEquals(2)
-            assertThat<Long?>(data, "valueNull").isGreaterThanEquals(1)
-            assertThat<Long>(data, "valueNull").isGreaterThanEquals(1)
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThanEquals(0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThanEquals(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<Long>().isGreaterThanEquals(2) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Long>().isGreaterThanEquals(1) }
 
             val results = this.results.toList()
 
@@ -505,7 +489,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than equals 0"), "Pass: data[value] is greater than equals 0", "1 >= 0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than equals 1"), "Pass: data[value] is greater than equals 1", "1 >= 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than equals 2"), "Fail: data[value] is greater than equals 2", "1 >= 2"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than equals 1"), "Fail: data[valueNull] is greater than equals 1", "null >= 1"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than equals 1"), "Fail: data[valueNull] is greater than equals 1", "null >= 1"),
             )
         }
@@ -515,13 +498,13 @@ internal class AssertThatTest {
     fun `test assertThat Float isGreaterThanEquals`() {
         val data = dataOf(
             "value" to 1.0f,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Float>(data, "value").isGreaterThanEquals(0.0f)
-            assertThat<Float>(data, "value").isGreaterThanEquals(1.0f)
-            assertThat<Float>(data, "value").isGreaterThanEquals(2.0f)
-            assertThat<Float?>(data, "valueNull").isGreaterThanEquals(1.0f)
-            assertThat<Float>(data, "valueNull").isGreaterThanEquals(1.0f)
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThanEquals(0.0f) }
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThanEquals(1.0f) }
+            assertThat(data).hasAttribute("value"){ it.isA<Float>().isGreaterThanEquals(2.0f) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Float>().isGreaterThanEquals(1.0f) }
 
             val results = this.results.toList()
 
@@ -529,7 +512,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than equals 0.0"), "Pass: data[value] is greater than equals 0.0", "1.0 >= 0.0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than equals 1.0"), "Pass: data[value] is greater than equals 1.0", "1.0 >= 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than equals 2.0"), "Fail: data[value] is greater than equals 2.0", "1.0 >= 2.0"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than equals 1.0"), "Fail: data[valueNull] is greater than equals 1.0", "null >= 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than equals 1.0"), "Fail: data[valueNull] is greater than equals 1.0", "null >= 1.0"),
             )
         }
@@ -539,13 +521,13 @@ internal class AssertThatTest {
     fun `test assertThat Double isGreaterThanEquals`() {
         val data = dataOf(
             "value" to 1.0,
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<Double>(data, "value").isGreaterThanEquals(0.0)
-            assertThat<Double>(data, "value").isGreaterThanEquals(1.0)
-            assertThat<Double>(data, "value").isGreaterThanEquals(2.0)
-            assertThat<Double?>(data, "valueNull").isGreaterThanEquals(1.0)
-            assertThat<Double>(data, "valueNull").isGreaterThanEquals(1.0)
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThanEquals(0.0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThanEquals(1.0) }
+            assertThat(data).hasAttribute("value"){ it.isA<Double>().isGreaterThanEquals(2.0) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<Double>().isGreaterThanEquals(1.0) }
 
             val results = this.results.toList()
 
@@ -553,7 +535,6 @@ internal class AssertThatTest {
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than equals 0.0"), "Pass: data[value] is greater than equals 0.0", "1.0 >= 0.0"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is greater than equals 1.0"), "Pass: data[value] is greater than equals 1.0", "1.0 >= 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] is greater than equals 2.0"), "Fail: data[value] is greater than equals 2.0", "1.0 >= 2.0"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than equals 1.0"), "Fail: data[valueNull] is greater than equals 1.0", "null >= 1.0"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is greater than equals 1.0"), "Fail: data[valueNull] is greater than equals 1.0", "null >= 1.0"),
             )
         }
@@ -564,13 +545,13 @@ internal class AssertThatTest {
         val data = dataOf(
             "value" to listOf(1, 2, 3),
             "valueEmpty" to emptyList<Int>(),
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<List<Int>>(data, "value").contains(1)
-            assertThat<List<Int>>(data, "valueEmpty").contains(1)
-            assertThat<List<Int>>(data, "value").contains(null)
-            assertThat<List<Int>?>(data, "valueNull").contains(1)
-            assertThat<List<Int>>(data, "valueNull").contains(1)
+            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().contains(1) }
+            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().contains(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().contains(null) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().contains(1) }
 
             val results = this.results.toList()
 
@@ -579,7 +560,32 @@ internal class AssertThatTest {
                 ValidationError(dataTrace().tag("assertion" to "data[valueEmpty] contains 1"), "Fail: data[valueEmpty] contains 1", "1 in []"),
                 ValidationError(dataTrace().tag("assertion" to "data[value] contains null"), "Fail: data[value] contains null", "null in [1, 2, 3]"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] contains 1"), "Fail: data[valueNull] contains 1", "1 in null"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] contains 1"), "Fail: data[valueNull] contains 1", "1 in null"),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat isOneOf Collection`() {
+        val collection = listOf(1, 2, 3)
+        val emptyCollection = emptyList<Int>()
+        val collectionWithNull = listOf<Int?>(null)
+        val data = dataOf(
+            "value" to 1,
+            "valueNull" to null,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat(data).hasAttribute("value"){ it.isOneOf(collection) }
+            assertThat(data).hasAttribute("value"){ it.isOneOf(emptyCollection) }
+            assertThat(data).hasAttribute("valueNull"){ it.isOneOf(collection) }
+            assertThat(data).hasAttribute("valueNull"){ it.isOneOf(collectionWithNull) }
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is one of [1, 2, 3]"), "Pass: data[value] is one of [1, 2, 3]", "1 in [1, 2, 3]"),
+                ValidationError(dataTrace().tag("assertion" to "data[value] is one of []"), "Fail: data[value] is one of []", "1 in []"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is one of [1, 2, 3]"), "Fail: data[valueNull] is one of [1, 2, 3]", "null in [1, 2, 3]"),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is one of [null]"), "Pass: data[valueNull] is one of [null]", "null in [null]"),
             )
         }
     }
@@ -589,13 +595,13 @@ internal class AssertThatTest {
         val data = dataOf(
             "value" to listOf(1, 2, 3),
             "valueEmpty" to emptyList<Int>(),
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<List<Int>>(data, "value").notContains(1)
-            assertThat<List<Int>>(data, "valueEmpty").notContains(1)
-            assertThat<List<Int>>(data, "value").notContains(null)
-            assertThat<List<Int>?>(data, "valueNull").notContains(1)
-            assertThat<List<Int>>(data, "valueNull").notContains(1)
+            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().notContains(1) }
+            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().notContains(1) }
+            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().notContains(null) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().notContains(1) }
 
             val results = this.results.toList()
 
@@ -603,7 +609,6 @@ internal class AssertThatTest {
                 ValidationError(dataTrace().tag("assertion" to "data[value] not contains 1"), "Fail: data[value] not contains 1", "1 not in [1, 2, 3]"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[valueEmpty] not contains 1"), "Pass: data[valueEmpty] not contains 1", "1 not in []"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] not contains null"), "Pass: data[value] not contains null", "null not in [1, 2, 3]"),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] not contains 1"), "Fail: data[valueNull] not contains 1", "1 not in null"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] not contains 1"), "Fail: data[valueNull] not contains 1", "1 not in null"),
             )
         }
@@ -614,19 +619,18 @@ internal class AssertThatTest {
         val data = dataOf(
             "value" to listOf(1, 2, 3),
             "valueEmpty" to emptyList<Int>(),
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<List<Int>>(data, "value").isEmpty()
-            assertThat<List<Int>>(data, "valueEmpty").isEmpty()
-            assertThat<List<Int>?>(data, "valueNull").isEmpty()
-            assertThat<List<Int>>(data, "valueNull").isEmpty()
+            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().isEmpty() }
+            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().isEmpty() }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().isEmpty() }
 
             val results = this.results.toList()
 
             junitAssertThat(results).contains(
                 ValidationError(dataTrace().tag("assertion" to "data[value] is empty"), "Fail: data[value] is empty", listOf(1, 2, 3)),
                 ValidationInfo(dataTrace().tag("assertion" to "data[valueEmpty] is empty"), "Pass: data[valueEmpty] is empty", emptyList<Int>()),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is empty"), "Fail: data[valueNull] is empty", null),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is empty"), "Fail: data[valueNull] is empty", null),
             )
         }
@@ -637,12 +641,12 @@ internal class AssertThatTest {
         val data = dataOf(
             "value" to listOf(1, 2, 3),
             "valueEmpty" to emptyList<Int>(),
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<List<Int>>(data, "value").isNullOrEmpty()
-            assertThat<List<Int>>(data, "valueEmpty").isNullOrEmpty()
-            assertThat<List<Int>?>(data, "valueNull").isNullOrEmpty()
-            assertThat<List<Int>>(data, "valueNull").isNullOrEmpty()
+            assertThat(data).hasAttribute("value"){ it.isA<List<Int>?>().isNullOrEmpty() }
+            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>?>().isNullOrEmpty() }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>?>().isNullOrEmpty() }
 
             val results = this.results.toList()
 
@@ -650,7 +654,6 @@ internal class AssertThatTest {
                 ValidationError(dataTrace().tag("assertion" to "data[value] is null or empty"), "Fail: data[value] is null or empty", listOf(1, 2, 3)),
                 ValidationInfo(dataTrace().tag("assertion" to "data[valueEmpty] is null or empty"), "Pass: data[valueEmpty] is null or empty", emptyList<Int>()),
                 ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is null or empty"), "Pass: data[valueNull] is null or empty", null),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is null or empty"), "Fail: data[valueNull] is null or empty", null),
             )
         }
     }
@@ -660,12 +663,13 @@ internal class AssertThatTest {
         val data = dataOf(
             "value" to listOf(1, 2, 3),
             "valueEmpty" to emptyList<Int>(),
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<List<Int>>(data, "value").isNotEmpty()
-            assertThat<List<Int>>(data, "valueEmpty").isNotEmpty()
-            assertThat<List<Int>?>(data, "valueNull").isNotEmpty()
-            assertThat<List<Int>>(data, "valueNull").isNotEmpty()
+            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().isNotEmpty() }
+            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().isNotEmpty() }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>?>().isNotEmpty() }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().isNotEmpty() }
 
             val results = this.results.toList()
 
@@ -683,12 +687,13 @@ internal class AssertThatTest {
         val data = dataOf(
             "value" to listOf(1, 2, 3),
             "valueEmpty" to emptyList<Int>(),
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<List<Int>>(data, "value").isSizeEquals(3)
-            assertThat<List<Int>>(data, "valueEmpty").isSizeEquals(3)
-            assertThat<List<Int>?>(data, "valueNull").isSizeEquals(3)
-            assertThat<List<Int>>(data, "valueNull").isSizeEquals(3)
+            assertThat(data).hasAttribute("value"){ it.isA<List<Int>>().isSizeEquals(3) }
+            assertThat(data).hasAttribute("valueEmpty"){ it.isA<List<Int>>().isSizeEquals(3) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>?>().isSizeEquals(3) }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<List<Int>>().isSizeEquals(3) }
 
             val results = this.results.toList()
 
@@ -705,18 +710,44 @@ internal class AssertThatTest {
     fun `test assertThat isNull`() {
         val data = dataOf(
             "value" to "Hello World",
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<String>(data, "value").isNull()
-            assertThat<String?>(data, "valueNull").isNull()
-            assertThat<String>(data, "valueNull").isNull()
+            assertThat(data).hasAttribute("value"){ it.isNull() }
+            assertThat(data).hasAttribute("valueNull"){ it.isNull() }
 
             val results = this.results.toList()
 
             junitAssertThat(results).contains(
                 ValidationError(dataTrace().tag("assertion" to "data[value] is null"), "Fail: data[value] is null", "Hello World"),
                 ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is null"), "Pass: data[valueNull] is null", null),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is null"), "Fail: data[valueNull] is null", null),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat isNullOr`() {
+        val data = dataOf(
+            "value" to "Hello World",
+            "valueNull" to null,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat(data).hasAttribute("value"){
+                it.isNullOr {
+                    it.isEqualTo("Hello World")
+                }
+            }
+            assertThat(data).hasAttribute("valueNull"){
+                it.isNullOr {
+                    it.isEqualTo("Hello World")
+                }
+            }
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is equal to Hello World"), "Pass: data[value] is equal to Hello World", "Hello World == Hello World"),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is null"), "Pass: data[valueNull] is null", null),
             )
         }
     }
@@ -725,18 +756,77 @@ internal class AssertThatTest {
     fun `test assertThat isNotNull`() {
         val data = dataOf(
             "value" to "Hello World",
+            "valueNull" to null,
         )
         with(Assertions(dataTrace())) {
-            assertThat<String>(data, "value").isNotNull()
-            assertThat<String?>(data, "valueNull").isNotNull()
-            assertThat<String>(data, "valueNull").isNotNull()
+            assertThat(data).hasAttribute("value"){ it.isNotNull() }
+            assertThat(data).hasAttribute("valueNull"){ it.isNotNull() }
 
             val results = this.results.toList()
 
             junitAssertThat(results).contains(
                 ValidationInfo(dataTrace().tag("assertion" to "data[value] is not null"), "Pass: data[value] is not null", "Hello World"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is not null"), "Fail: data[valueNull] is not null", null),
-                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is not null"), "Fail: data[valueNull] is not null", null),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat isA`() {
+        val data = dataOf(
+            "valueStr" to "Hello World",
+            "valueNull" to null,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat(data).hasAttribute("valueStr"){ it.isA<String>() }
+            assertThat(data).hasAttribute("valueStr"){ it.isA<Int>() }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<String>() }
+            assertThat(data).hasAttribute("valueNull"){ it.isA<String?>() }
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueStr] is a kotlin.String"), "Pass: data[valueStr] is a kotlin.String", "Hello World"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueStr] is a kotlin.Int"), "Fail: data[valueStr] is a kotlin.Int", "Hello World"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is a kotlin.String"), "Fail: data[valueNull] is a kotlin.String", null),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is a kotlin.String"), "Pass: data[valueNull] is a kotlin.String", null),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat or`() {
+        val data = dataOf(
+            "value" to "Hello World",
+            "valueNull" to null,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat(data).hasAttribute("value") { attr ->
+                attr.or(
+                    { it.isNull() },
+                    { it.isEqualTo("Hello World")}
+                )
+            }
+            assertThat(data).hasAttribute("valueNull"){ attr ->
+                attr.or(
+                    { it.isNull() },
+                    { it.isEqualTo("Hello World")}
+                )
+            }
+            assertThat(data).hasAttribute("value") { attr ->
+                attr.or(
+                    { it.isNull() },
+                    { it.isEqualTo("Good Bye")}
+                )
+            }
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is equal to Hello World"), "Pass: data[value] is equal to Hello World", "Hello World == Hello World"),
+                ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is null"), "Pass: data[valueNull] is null", null),
+                ValidationError(dataTrace().tag("assertion" to "data[value] is null"), "Fail: data[value] is null", "Hello World"),
+                ValidationError(dataTrace().tag("assertion" to "data[value] is equal to Good Bye"), "Fail: data[value] is equal to Good Bye", "Hello World == Good Bye"),
             )
         }
     }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -110,45 +110,93 @@ internal class AssertThatTest {
             )
         }
     }
-//
-//    @Test
-//    fun `test assertEquals`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertEquals("test 1 = 1", 1, 1)
-//        assertions.assertEquals("test 1 = 2", 1, 2)
-//        assertions.assertEquals("test \"hello\" = \"hello\"", "hello", "hello")
-//        assertions.assertEquals("test \"hello\" = \"world\"", "hello", "world")
-//        assertions.assertEquals("test null = null", null, null)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationInfo(dataTrace().tag("assertion" to "test 1 = 1"), "Pass: test 1 = 1", "1 == 1"),
-//            ValidationError(dataTrace().tag("assertion" to "test 1 = 2"), "Fail: test 1 = 2", "1 == 2"),
-//            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" = \"hello\""), "Pass: test \"hello\" = \"hello\"", "hello == hello"),
-//            ValidationError(dataTrace().tag("assertion" to "test \"hello\" = \"world\""), "Fail: test \"hello\" = \"world\"", "hello == world"),
-//            ValidationInfo(dataTrace().tag("assertion" to "test null = null"), "Pass: test null = null", "null == null"),
-//        )
-//    }
-//
-//    @Test
-//    fun `test assertNotEquals`() {
-//        val assertions = Assertions(dataTrace())
-//
-//        assertions.assertNotEquals("test 1 != 1", 1, 1)
-//        assertions.assertNotEquals("test 1 != 2", 1, 2)
-//        assertions.assertNotEquals("test \"hello\" != \"hello\"", "hello", "hello")
-//        assertions.assertNotEquals("test \"hello\" != \"world\"", "hello", "world")
-//        assertions.assertNotEquals("test null != null", null, null)
-//
-//        assertThat(assertions.results).containsExactly(
-//            ValidationError(dataTrace().tag("assertion" to "test 1 != 1"), "Fail: test 1 != 1", "1 != 1"),
-//            ValidationInfo(dataTrace().tag("assertion" to "test 1 != 2"), "Pass: test 1 != 2", "1 != 2"),
-//            ValidationError(dataTrace().tag("assertion" to "test \"hello\" != \"hello\""), "Fail: test \"hello\" != \"hello\"", "hello != hello"),
-//            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" != \"world\""), "Pass: test \"hello\" != \"world\"", "hello != world"),
-//            ValidationError(dataTrace().tag("assertion" to "test null != null"), "Fail: test null != null", "null != null"),
-//        )
-//    }
-//
+
+    @Test
+    fun `test assertThat isEquals`() {
+        val data = dataOf(
+            "value1" to true,
+            "value2" to "Hello World"
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<Boolean>(data, "value1").isEqualTo(true)
+            assertThat<Boolean>(data, "value1").isEqualTo(false)
+            assertThat<String>(data, "value2").isEqualTo("Hello World")
+            assertThat<String>(data, "value2").isEqualTo("Goodbye")
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value1] is equal to true"), "Pass: data[value1] is equal to true", "true == true"),
+                ValidationError(dataTrace().tag("assertion" to "data[value1] is equal to false"), "Fail: data[value1] is equal to false", "true == false"),
+                ValidationInfo(dataTrace().tag("assertion" to "data[value2] is equal to Hello World"), "Pass: data[value2] is equal to Hello World", "Hello World == Hello World"),
+                ValidationError(dataTrace().tag("assertion" to "data[value2] is equal to Goodbye"), "Fail: data[value2] is equal to Goodbye", "Hello World == Goodbye"),
+            )
+        }
+    }
+
+    @Test
+        fun `test assertThat isNotEquals`() {
+            val data = dataOf(
+                "value1" to true,
+                "value2" to "Hello World"
+            )
+            with(Assertions(dataTrace())) {
+                assertThat<Boolean>(data, "value1").isNotEqualTo(true)
+                assertThat<Boolean>(data, "value1").isNotEqualTo(false)
+                assertThat<String>(data, "value2").isNotEqualTo("Hello World")
+                assertThat<String>(data, "value2").isNotEqualTo("Goodbye")
+
+                val results = this.results.toList()
+
+                junitAssertThat(results).contains(
+                    ValidationError(dataTrace().tag("assertion" to "data[value1] is not equal to true"), "Pass: data[value1] is not equal to true", "true != true"),
+                    ValidationInfo(dataTrace().tag("assertion" to "data[value1] is not equal to false"), "Fail: data[value1] is not equal to false", "true != false"),
+                    ValidationError(dataTrace().tag("assertion" to "data[value2] is not equal to Hello World"), "Pass: data[value2] is not equal to Hello World", "Hello World != Hello World"),
+                    ValidationInfo(dataTrace().tag("assertion" to "data[value2] is not equal to Goodbye"), "Fail: data[value2] is not equal to Goodbye", "Hello World != Goodbye"),
+                )
+            }
+        }
+
+    @Test
+    fun `test assertThat Int isLessThan`() {
+        val data = dataOf(
+            "value" to 1,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<Int>(data, "value").isLessThan(1)
+            assertThat<Int>(data, "value").isLessThan(2)
+            assertThat<Int?>(data, "valueNull").isLessThan(1)
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than 1"), "Pass: data[value] is less than 1", "1 < 1"),
+                ValidationError(dataTrace().tag("assertion" to "data[value] is less than 2"), "Fail: data[value] is less than 2", "1 < 2"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than 1"), "Fail: data[valueNull] is less than 1", "null < 1"),
+            )
+        }
+    }
+
+    @Test
+    fun `test assertThat Long isLessThan`() {
+        val data = dataOf(
+            "value" to 1,
+        )
+        with(Assertions(dataTrace())) {
+            assertThat<Long>(data, "value").isLessThan(1)
+            assertThat<Long>(data, "value").isLessThan(2)
+            assertThat<Long?>(data, "valueNull").isLessThan(1)
+
+            val results = this.results.toList()
+
+            junitAssertThat(results).contains(
+                ValidationInfo(dataTrace().tag("assertion" to "data[value] is less than 1"), "Pass: data[value] is less than 1", "1 < 1"),
+                ValidationError(dataTrace().tag("assertion" to "data[value] is less than 2"), "Fail: data[value] is less than 2", "1 < 2"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueNull] is less than 1"), "Fail: data[valueNull] is less than 1", "null < 1"),
+            )
+        }
+    }
+
 //    @Test
 //    fun `test assertLessThan(Int)`() {
 //        val assertions = Assertions(dataTrace())

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertionsTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertionsTest.kt
@@ -1,0 +1,453 @@
+package com.shoprunner.baleen
+
+import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class AssertionsTest {
+
+    @Test
+    fun `test assertTrue`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertTrue("test true", true)
+        assertions.assertTrue("test false", false)
+        assertions.assertTrue("test null", null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationInfo(dataTrace().tag("assertion" to "test true"), "Pass: test true", null),
+            ValidationError(dataTrace().tag("assertion" to "test false"), "Fail: test false", null),
+            ValidationError(dataTrace().tag("assertion" to "test null"), "Fail: test null", null)
+        )
+    }
+
+    @Test
+    fun `test assertFalse`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertFalse("test true", true)
+        assertions.assertFalse("test false", false)
+        assertions.assertFalse("test null", null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test true"), "Fail: test true", null),
+            ValidationInfo(dataTrace().tag("assertion" to "test false"), "Pass: test false", null),
+            ValidationError(dataTrace().tag("assertion" to "test null"), "Fail: test null", null)
+        )
+    }
+
+    @Test
+    fun `test assertEquals`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertEquals("test 1 = 1", 1, 1)
+        assertions.assertEquals("test 1 = 2", 1, 2)
+        assertions.assertEquals("test \"hello\" = \"hello\"", "hello", "hello")
+        assertions.assertEquals("test \"hello\" = \"world\"", "hello", "world")
+        assertions.assertEquals("test null = null", null, null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 = 1"), "Pass: test 1 = 1", "1 == 1"),
+            ValidationError(dataTrace().tag("assertion" to "test 1 = 2"), "Fail: test 1 = 2", "1 == 2"),
+            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" = \"hello\""), "Pass: test \"hello\" = \"hello\"", "hello == hello"),
+            ValidationError(dataTrace().tag("assertion" to "test \"hello\" = \"world\""), "Fail: test \"hello\" = \"world\"", "hello == world"),
+            ValidationInfo(dataTrace().tag("assertion" to "test null = null"), "Pass: test null = null", "null == null"),
+        )
+    }
+
+    @Test
+    fun `test assertNotEquals`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertNotEquals("test 1 != 1", 1, 1)
+        assertions.assertNotEquals("test 1 != 2", 1, 2)
+        assertions.assertNotEquals("test \"hello\" != \"hello\"", "hello", "hello")
+        assertions.assertNotEquals("test \"hello\" != \"world\"", "hello", "world")
+        assertions.assertNotEquals("test null != null", null, null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 != 1"), "Fail: test 1 != 1", "1 != 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 != 2"), "Pass: test 1 != 2", "1 != 2"),
+            ValidationError(dataTrace().tag("assertion" to "test \"hello\" != \"hello\""), "Fail: test \"hello\" != \"hello\"", "hello != hello"),
+            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" != \"world\""), "Pass: test \"hello\" != \"world\"", "hello != world"),
+            ValidationError(dataTrace().tag("assertion" to "test null != null"), "Fail: test null != null", "null != null"),
+        )
+    }
+
+    @Test
+    fun `test assertLessThan(Int)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertLessThan("test 1 < 1", 1.toInt(), 1)
+        assertions.assertLessThan("test 1 < 2", 1.toInt(), 2)
+        assertions.assertLessThan("test null < null", null?.toInt(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 < 1"), "Fail: test 1 < 1", "1 < 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 < 2"), "Pass: test 1 < 2", "1 < 2"),
+            ValidationError(dataTrace().tag("assertion" to "test null < null"), "Fail: test null < null", "null < null"),
+        )
+    }
+
+    @Test
+    fun `test assertLessThan(Long)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertLessThan("test 1 < 1", 1L, 1L)
+        assertions.assertLessThan("test 1 < 2", 1L, 2L)
+        assertions.assertLessThan("test null < null", null?.toLong(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 < 1"), "Fail: test 1 < 1", "1 < 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 < 2"), "Pass: test 1 < 2", "1 < 2"),
+            ValidationError(dataTrace().tag("assertion" to "test null < null"), "Fail: test null < null", "null < null"),
+        )
+    }
+
+    @Test
+    fun `test assertLessThan(Float)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertLessThan("test 1 < 1", 1f, 1f)
+        assertions.assertLessThan("test 1 < 2", 1f, 2f)
+        assertions.assertLessThan("test null < null", null?.toFloat(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 < 1"), "Fail: test 1 < 1", "1.0 < 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 < 2"), "Pass: test 1 < 2", "1.0 < 2.0"),
+            ValidationError(dataTrace().tag("assertion" to "test null < null"), "Fail: test null < null", "null < null"),
+        )
+    }
+
+    @Test
+    fun `test assertLessThan(Double)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertLessThan("test 1 < 1", 1.0, 1.0)
+        assertions.assertLessThan("test 1 < 2", 1.0, 2.0)
+        assertions.assertLessThan("test null < null", null?.toDouble(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 < 1"), "Fail: test 1 < 1", "1.0 < 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 < 2"), "Pass: test 1 < 2", "1.0 < 2.0"),
+            ValidationError(dataTrace().tag("assertion" to "test null < null"), "Fail: test null < null", "null < null"),
+        )
+    }
+
+    @Test
+    fun `test assertLessThanEquals(Int)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertLessThanEquals("test 1 <= 0", 1.toInt(), 0)
+        assertions.assertLessThanEquals("test 1 <= 1", 1.toInt(), 1)
+        assertions.assertLessThanEquals("test 1 <= 2", 1.toInt(), 2)
+        assertions.assertLessThanEquals("test null <= null", null?.toInt(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 <= 0"), "Fail: test 1 <= 0", "1 <= 0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 1"), "Pass: test 1 <= 1", "1 <= 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 2"), "Pass: test 1 <= 2", "1 <= 2"),
+            ValidationError(dataTrace().tag("assertion" to "test null <= null"), "Fail: test null <= null", "null <= null"),
+        )
+    }
+
+    @Test
+    fun `test assertLessThanEquals(Long)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertLessThanEquals("test 1 <= 0", 1L, 0)
+        assertions.assertLessThanEquals("test 1 <= 1", 1L, 1L)
+        assertions.assertLessThanEquals("test 1 <= 2", 1L, 2L)
+        assertions.assertLessThanEquals("test null <= null", null?.toLong(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 <= 0"), "Fail: test 1 <= 0", "1 <= 0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 1"), "Pass: test 1 <= 1", "1 <= 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 2"), "Pass: test 1 <= 2", "1 <= 2"),
+            ValidationError(dataTrace().tag("assertion" to "test null <= null"), "Fail: test null <= null", "null <= null"),
+        )
+    }
+
+    @Test
+    fun `test assertLessThanEquals(Float)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertLessThanEquals("test 1 <= 0", 1f, 0f)
+        assertions.assertLessThanEquals("test 1 <= 1", 1f, 1f)
+        assertions.assertLessThanEquals("test 1 <= 2", 1f, 2f)
+        assertions.assertLessThanEquals("test null <= null", null?.toFloat(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 <= 0"), "Fail: test 1 <= 0", "1.0 <= 0.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 1"), "Pass: test 1 <= 1", "1.0 <= 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 2"), "Pass: test 1 <= 2", "1.0 <= 2.0"),
+            ValidationError(dataTrace().tag("assertion" to "test null <= null"), "Fail: test null <= null", "null <= null"),
+        )
+    }
+
+    @Test
+    fun `test assertLessThanEquals(Double)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertLessThanEquals("test 1 <= 0", 1.0, 0.0)
+        assertions.assertLessThanEquals("test 1 <= 1", 1.0, 1.0)
+        assertions.assertLessThanEquals("test 1 <= 2", 1.0, 2.0)
+        assertions.assertLessThanEquals("test null <= null", null?.toDouble(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 <= 0"), "Fail: test 1 <= 0", "1.0 <= 0.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 1"), "Pass: test 1 <= 1", "1.0 <= 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 <= 2"), "Pass: test 1 <= 2", "1.0 <= 2.0"),
+            ValidationError(dataTrace().tag("assertion" to "test null <= null"), "Fail: test null <= null", "null <= null"),
+        )
+    }
+
+    @Test
+    fun `test assertGreaterThan(Int)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertGreaterThan("test 1 > 1", 1.toInt(), 1)
+        assertions.assertGreaterThan("test 2 > 1", 2.toInt(), 1)
+        assertions.assertGreaterThan("test null > null", null?.toInt(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 > 1"), "Fail: test 1 > 1", "1 > 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 2 > 1"), "Pass: test 2 > 1", "2 > 1"),
+            ValidationError(dataTrace().tag("assertion" to "test null > null"), "Fail: test null > null", "null > null"),
+        )
+    }
+
+    @Test
+    fun `test assertGreaterThan(Long)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertGreaterThan("test 1 > 1", 1L, 1L)
+        assertions.assertGreaterThan("test 2 > 1", 2L, 1L)
+        assertions.assertGreaterThan("test null > null", null?.toLong(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 > 1"), "Fail: test 1 > 1", "1 > 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 2 > 1"), "Pass: test 2 > 1", "2 > 1"),
+            ValidationError(dataTrace().tag("assertion" to "test null > null"), "Fail: test null > null", "null > null"),
+        )
+    }
+
+    @Test
+    fun `test assertGreaterThan(Float)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertGreaterThan("test 1 > 1", 1f, 1f)
+        assertions.assertGreaterThan("test 2 > 1", 2f, 1f)
+        assertions.assertGreaterThan("test null > null", null?.toFloat(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 > 1"), "Fail: test 1 > 1", "1.0 > 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 2 > 1"), "Pass: test 2 > 1", "2.0 > 1.0"),
+            ValidationError(dataTrace().tag("assertion" to "test null > null"), "Fail: test null > null", "null > null"),
+        )
+    }
+
+    @Test
+    fun `test assertGreaterThan(Double)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertGreaterThan("test 1 > 1", 1.0, 1.0)
+        assertions.assertGreaterThan("test 2 > 1", 2.0, 1.0)
+        assertions.assertGreaterThan("test null > null", null?.toDouble(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 > 1"), "Fail: test 1 > 1", "1.0 > 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 2 > 1"), "Pass: test 2 > 1", "2.0 > 1.0"),
+            ValidationError(dataTrace().tag("assertion" to "test null > null"), "Fail: test null > null", "null > null"),
+        )
+    }
+
+    @Test
+    fun `test assertGreaterThanEquals(Int)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertGreaterThanEquals("test 0 >= 1", 0.toInt(), 1)
+        assertions.assertGreaterThanEquals("test 1 >= 1", 1.toInt(), 1)
+        assertions.assertGreaterThanEquals("test 2 >= 1", 2.toInt(), 1)
+        assertions.assertGreaterThanEquals("test null >= null", null?.toInt(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 0 >= 1"), "Fail: test 0 >= 1", "0 >= 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 >= 1"), "Pass: test 1 >= 1", "1 >= 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 2 >= 1"), "Pass: test 2 >= 1", "2 >= 1"),
+            ValidationError(dataTrace().tag("assertion" to "test null >= null"), "Fail: test null >= null", "null >= null"),
+        )
+    }
+
+    @Test
+    fun `test assertGreaterThanEquals(Long)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertGreaterThanEquals("test 0 >= 1", 0L, 1)
+        assertions.assertGreaterThanEquals("test 1 >= 1", 1L, 1L)
+        assertions.assertGreaterThanEquals("test 2 >= 1", 2L, 1L)
+        assertions.assertGreaterThanEquals("test null >= null", null?.toLong(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 0 >= 1"), "Fail: test 0 >= 1", "0 >= 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 >= 1"), "Pass: test 1 >= 1", "1 >= 1"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 2 >= 1"), "Pass: test 2 >= 1", "2 >= 1"),
+            ValidationError(dataTrace().tag("assertion" to "test null >= null"), "Fail: test null >= null", "null >= null"),
+        )
+    }
+
+    @Test
+    fun `test assertGreaterThanEquals(Float)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertGreaterThanEquals("test 0 >= 1", 0f, 1f)
+        assertions.assertGreaterThanEquals("test 1 >= 1", 1f, 1f)
+        assertions.assertGreaterThanEquals("test 2 >= 1", 2f, 1f)
+        assertions.assertGreaterThanEquals("test null >= null", null?.toFloat(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 0 >= 1"), "Fail: test 0 >= 1", "0.0 >= 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 >= 1"), "Pass: test 1 >= 1", "1.0 >= 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 2 >= 1"), "Pass: test 2 >= 1", "2.0 >= 1.0"),
+            ValidationError(dataTrace().tag("assertion" to "test null >= null"), "Fail: test null >= null", "null >= null"),
+        )
+    }
+
+    @Test
+    fun `test assertGreaterThanEquals(Double)`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertGreaterThanEquals("test 0 >= 1", 0.0, 1.0)
+        assertions.assertGreaterThanEquals("test 1 >= 1", 1.0, 1.0)
+        assertions.assertGreaterThanEquals("test 2 >= 1", 2.0, 1.0)
+        assertions.assertGreaterThanEquals("test null >= null", null?.toDouble(), null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 0 >= 1"), "Fail: test 0 >= 1", "0.0 >= 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 >= 1"), "Pass: test 1 >= 1", "1.0 >= 1.0"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 2 >= 1"), "Pass: test 2 >= 1", "2.0 >= 1.0"),
+            ValidationError(dataTrace().tag("assertion" to "test null >= null"), "Fail: test null >= null", "null >= null"),
+        )
+    }
+
+    @Test
+    fun `test assertContains`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertContains("test 1 in [1,2,3]", listOf(1,2,3), 1)
+        assertions.assertContains("test 1 in []", emptyList<Int>(), 1)
+        assertions.assertContains("test null in [1,2,3]", listOf(1,2,3), null)
+        assertions.assertContains("test 1 in null", null, 1)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 in [1,2,3]"), "Pass: test 1 in [1,2,3]", "1 in [1, 2, 3]"),
+            ValidationError(dataTrace().tag("assertion" to "test 1 in []"), "Fail: test 1 in []", "1 in []"),
+            ValidationError(dataTrace().tag("assertion" to "test null in [1,2,3]"), "Fail: test null in [1,2,3]", "null in [1, 2, 3]"),
+            ValidationError(dataTrace().tag("assertion" to "test 1 in null"), "Fail: test 1 in null", "1 in null"),
+        )
+    }
+
+    @Test
+    fun `test assertNotContains`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertNotContains("test 1 !in [1,2,3]", listOf(1,2,3), 1)
+        assertions.assertNotContains("test 1 !in []", emptyList<Int>(), 1)
+        assertions.assertNotContains("test null !in [1,2,3]", listOf(1,2,3), null)
+        assertions.assertNotContains("test 1 !in null", null, 1)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test 1 !in [1,2,3]"), "Fail: test 1 !in [1,2,3]", "1 not in [1, 2, 3]"),
+            ValidationInfo(dataTrace().tag("assertion" to "test 1 !in []"), "Pass: test 1 !in []", "1 not in []"),
+            ValidationInfo(dataTrace().tag("assertion" to "test null !in [1,2,3]"), "Pass: test null !in [1,2,3]", "null not in [1, 2, 3]"),
+            ValidationError(dataTrace().tag("assertion" to "test 1 !in null"), "Fail: test 1 !in null", "1 not in null"),
+        )
+    }
+
+    @Test
+    fun `test assertEmpty`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertEmpty("test [1,2,3] is empty", listOf(1,2,3))
+        assertions.assertEmpty("test [] is empty", emptyList<Int>())
+        assertions.assertEmpty("test null is empty", null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test [1,2,3] is empty"), "Fail: test [1,2,3] is empty", listOf(1, 2, 3)),
+            ValidationInfo(dataTrace().tag("assertion" to "test [] is empty"), "Pass: test [] is empty", emptyList<Int>()),
+            ValidationError(dataTrace().tag("assertion" to "test null is empty"), "Fail: test null is empty", null),
+        )
+    }
+
+    @Test
+    fun `test assertNullOrEmpty`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertNullOrEmpty("test [1,2,3] is null or empty", listOf(1,2,3))
+        assertions.assertNullOrEmpty("test [] is null or empty", emptyList<Int>())
+        assertions.assertNullOrEmpty("test null is null or empty", null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test [1,2,3] is null or empty"), "Fail: test [1,2,3] is null or empty", listOf(1, 2, 3)),
+            ValidationInfo(dataTrace().tag("assertion" to "test [] is null or empty"), "Pass: test [] is null or empty", emptyList<Int>()),
+            ValidationInfo(dataTrace().tag("assertion" to "test null is null or empty"), "Pass: test null is null or empty", null),
+        )
+    }
+
+    @Test
+    fun `test assertNotEmpty`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertNotEmpty("test [1,2,3] is not empty", listOf(1,2,3))
+        assertions.assertNotEmpty("test [] is not empty", emptyList<Int>())
+        assertions.assertNotEmpty("test null is not empty", null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationInfo(dataTrace().tag("assertion" to "test [1,2,3] is not empty"), "Pass: test [1,2,3] is not empty", listOf(1, 2, 3)),
+            ValidationError(dataTrace().tag("assertion" to "test [] is not empty"), "Fail: test [] is not empty", emptyList<Int>()),
+            ValidationError(dataTrace().tag("assertion" to "test null is not empty"), "Fail: test null is not empty", null),
+        )
+    }
+
+    @Test
+    fun `test assertSizeEquals`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertSizeEquals("test [1,2,3] is length 3", listOf(1,2,3), 3)
+        assertions.assertSizeEquals("test [] is length 3", emptyList<Int>(), 3)
+        assertions.assertSizeEquals("test null is length 3", null, 3)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationInfo(dataTrace().tag("assertion" to "test [1,2,3] is length 3"), "Pass: test [1,2,3] is length 3", "3 = size([1, 2, 3])"),
+            ValidationError(dataTrace().tag("assertion" to "test [] is length 3"), "Fail: test [] is length 3", "3 = size([])"),
+            ValidationError(dataTrace().tag("assertion" to "test null is length 3"), "Fail: test null is length 3", "3 = size(null)"),
+        )
+    }
+
+    @Test
+    fun `test assertNull`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertNull("test \"hello\" is null", "hello")
+        assertions.assertNull("test null is null", null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationError(dataTrace().tag("assertion" to "test \"hello\" is null"), "Fail: test \"hello\" is null", "hello"),
+            ValidationInfo(dataTrace().tag("assertion" to "test null is null"), "Pass: test null is null", null),
+        )
+    }
+
+    @Test
+    fun `test assertNotNull`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertNotNull("test \"hello\" is not null", "hello")
+        assertions.assertNotNull("test null is not null", null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" is not null"), "Pass: test \"hello\" is not null", "hello"),
+            ValidationError(dataTrace().tag("assertion" to "test null is not null"), "Fail: test null is not null", null),
+        )
+    }
+}

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertionsTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertionsTest.kt
@@ -3,8 +3,10 @@ package com.shoprunner.baleen
 import com.shoprunner.baleen.SequenceAssert.Companion.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import kotlin.contracts.ExperimentalContracts
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExperimentalContracts
 internal class AssertionsTest {
 
     @Test
@@ -335,9 +337,9 @@ internal class AssertionsTest {
     fun `test assertContains`() {
         val assertions = Assertions(dataTrace())
 
-        assertions.assertContains("test 1 in [1,2,3]", listOf(1,2,3), 1)
+        assertions.assertContains("test 1 in [1,2,3]", listOf(1, 2, 3), 1)
         assertions.assertContains("test 1 in []", emptyList<Int>(), 1)
-        assertions.assertContains("test null in [1,2,3]", listOf(1,2,3), null)
+        assertions.assertContains("test null in [1,2,3]", listOf(1, 2, 3), null)
         assertions.assertContains("test 1 in null", null, 1)
 
         assertThat(assertions.results).containsExactly(
@@ -352,9 +354,9 @@ internal class AssertionsTest {
     fun `test assertNotContains`() {
         val assertions = Assertions(dataTrace())
 
-        assertions.assertNotContains("test 1 !in [1,2,3]", listOf(1,2,3), 1)
+        assertions.assertNotContains("test 1 !in [1,2,3]", listOf(1, 2, 3), 1)
         assertions.assertNotContains("test 1 !in []", emptyList<Int>(), 1)
-        assertions.assertNotContains("test null !in [1,2,3]", listOf(1,2,3), null)
+        assertions.assertNotContains("test null !in [1,2,3]", listOf(1, 2, 3), null)
         assertions.assertNotContains("test 1 !in null", null, 1)
 
         assertThat(assertions.results).containsExactly(
@@ -369,7 +371,7 @@ internal class AssertionsTest {
     fun `test assertEmpty`() {
         val assertions = Assertions(dataTrace())
 
-        assertions.assertEmpty("test [1,2,3] is empty", listOf(1,2,3))
+        assertions.assertEmpty("test [1,2,3] is empty", listOf(1, 2, 3))
         assertions.assertEmpty("test [] is empty", emptyList<Int>())
         assertions.assertEmpty("test null is empty", null)
 
@@ -384,7 +386,7 @@ internal class AssertionsTest {
     fun `test assertNullOrEmpty`() {
         val assertions = Assertions(dataTrace())
 
-        assertions.assertNullOrEmpty("test [1,2,3] is null or empty", listOf(1,2,3))
+        assertions.assertNullOrEmpty("test [1,2,3] is null or empty", listOf(1, 2, 3))
         assertions.assertNullOrEmpty("test [] is null or empty", emptyList<Int>())
         assertions.assertNullOrEmpty("test null is null or empty", null)
 
@@ -399,7 +401,7 @@ internal class AssertionsTest {
     fun `test assertNotEmpty`() {
         val assertions = Assertions(dataTrace())
 
-        assertions.assertNotEmpty("test [1,2,3] is not empty", listOf(1,2,3))
+        assertions.assertNotEmpty("test [1,2,3] is not empty", listOf(1, 2, 3))
         assertions.assertNotEmpty("test [] is not empty", emptyList<Int>())
         assertions.assertNotEmpty("test null is not empty", null)
 
@@ -414,7 +416,7 @@ internal class AssertionsTest {
     fun `test assertSizeEquals`() {
         val assertions = Assertions(dataTrace())
 
-        assertions.assertSizeEquals("test [1,2,3] is length 3", listOf(1,2,3), 3)
+        assertions.assertSizeEquals("test [1,2,3] is length 3", listOf(1, 2, 3), 3)
         assertions.assertSizeEquals("test [] is length 3", emptyList<Int>(), 3)
         assertions.assertSizeEquals("test null is length 3", null, 3)
 
@@ -448,6 +450,23 @@ internal class AssertionsTest {
         assertThat(assertions.results).containsExactly(
             ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" is not null"), "Pass: test \"hello\" is not null", "hello"),
             ValidationError(dataTrace().tag("assertion" to "test null is not null"), "Fail: test null is not null", null),
+        )
+    }
+
+    @Test
+    fun `test assertInstanceOf`() {
+        val assertions = Assertions(dataTrace())
+
+        assertions.assertInstanceOf<String>("test \"hello\" is a String", "hello")
+        assertions.assertInstanceOf<String>("test 1 is a String", 1)
+        assertions.assertInstanceOf<String>("test null is a String", null)
+        assertions.assertInstanceOf<String?>("test null is a nullable String", null)
+
+        assertThat(assertions.results).containsExactly(
+            ValidationInfo(dataTrace().tag("assertion" to "test \"hello\" is a String"), "Pass: test \"hello\" is a String", "hello is a kotlin.String"),
+            ValidationError(dataTrace().tag("assertion" to "test 1 is a String"), "Fail: test 1 is a String", "1 is a kotlin.Int"),
+            ValidationError(dataTrace().tag("assertion" to "test null is a String"), "Fail: test null is a String", "null is a kotlin.String?"),
+            ValidationInfo(dataTrace().tag("assertion" to "test null is a nullable String"), "Pass: test null is a nullable String", "null is a kotlin.String?"),
         )
     }
 }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/BaleenTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/BaleenTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import kotlin.contracts.ExperimentalContracts
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class BaleenTest {
@@ -261,7 +262,7 @@ internal class BaleenTest {
         val dataDesc = "FavoriteNumber".describeAs {
             "favorite number".type(IntType()).describe {
                 test("favorite number is 42") { data ->
-                    assertEquals("favorite number == 42", data.getAsInt("favorite number"), 42)
+                    assertEquals("favorite number == 42", data.getAsIntOrNull("favorite number"), 42)
                 }
             }
         }
@@ -277,10 +278,33 @@ internal class BaleenTest {
     }
 
     @Test
+    @ExperimentalContracts
+    fun `junit style attribute test - assertThat`() {
+        val dataDesc = "FavoriteNumber".describeAs {
+            "favorite number".type(IntType()).describe {
+                test("favorite number is 42") { data ->
+                    assertThat { data.getAsInt("favorite number") }.isEqualTo(42)
+                }
+            }
+        }
+
+        assertThat(dataDesc.validate(dataOf("favorite number" to 42))).isValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 42)).results).contains(
+            ValidationInfo(dataTrace().tag("test" to "favorite number is 42", "assertion" to "assertThat<kotlin.Int>()"), "Pass: assertThat<kotlin.Int>()", "42 is a kotlin.Int"),
+            ValidationInfo(dataTrace().tag("test" to "favorite number is 42", "assertion" to "is equal to 42"), "Pass: is equal to 42", "42 == 42")
+        )
+        assertThat(dataDesc.validate(dataOf("favorite number" to 41))).isNotValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 41)).results).contains(
+            ValidationInfo(dataTrace().tag("test" to "favorite number is 42", "assertion" to "assertThat<kotlin.Int>()"), "Pass: assertThat<kotlin.Int>()", "41 is a kotlin.Int"),
+            ValidationError(dataTrace().tag("test" to "favorite number is 42", "assertion" to "is equal to 42"), "Fail: is equal to 42", "41 == 42")
+        )
+    }
+
+    @Test
     fun `junit style test`() {
         val dataDesc = "FavoriteNumber".describeAs {
             test("favorite number is 42") { data ->
-                assertEquals("favorite number == 42", data.getAsInt("favorite number"), 42)
+                assertEquals("favorite number == 42", data.getAsIntOrNull("favorite number"), 42)
             }
         }
 
@@ -291,6 +315,27 @@ internal class BaleenTest {
         assertThat(dataDesc.validate(dataOf("favorite number" to 41))).isNotValid()
         assertThat(dataDesc.validate(dataOf("favorite number" to 41)).results).contains(
             ValidationError(dataTrace().tag("test" to "favorite number is 42", "assertion" to "favorite number == 42"), "Fail: favorite number == 42", "41 == 42")
+        )
+    }
+
+    @Test
+    @ExperimentalContracts
+    fun `junit style test - assertThat`() {
+        val dataDesc = "FavoriteNumber".describeAs {
+            test("favorite number is 42") { data ->
+                assertThat { data.getAsInt("favorite number") }.isEqualTo(42)
+            }
+        }
+
+        assertThat(dataDesc.validate(dataOf("favorite number" to 42))).isValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 42)).results).contains(
+            ValidationInfo(dataTrace().tag("test" to "favorite number is 42", "assertion" to "assertThat<kotlin.Int>()"), "Pass: assertThat<kotlin.Int>()", "42 is a kotlin.Int"),
+            ValidationInfo(dataTrace().tag("test" to "favorite number is 42", "assertion" to "is equal to 42"), "Pass: is equal to 42", "42 == 42")
+        )
+        assertThat(dataDesc.validate(dataOf("favorite number" to 41))).isNotValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 41)).results).contains(
+            ValidationInfo(dataTrace().tag("test" to "favorite number is 42", "assertion" to "assertThat<kotlin.Int>()"), "Pass: assertThat<kotlin.Int>()", "41 is a kotlin.Int"),
+            ValidationError(dataTrace().tag("test" to "favorite number is 42", "assertion" to "is equal to 42"), "Fail: is equal to 42", "41 == 42")
         )
     }
 }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/BaleenTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/BaleenTest.kt
@@ -267,7 +267,13 @@ internal class BaleenTest {
         }
 
         assertThat(dataDesc.validate(dataOf("favorite number" to 42))).isValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 42)).results).contains(
+            ValidationInfo(dataTrace().tag("test" to "favorite number is 42", "assertion" to "favorite number == 42"), "Pass: favorite number == 42", "42 == 42")
+        )
         assertThat(dataDesc.validate(dataOf("favorite number" to 41))).isNotValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 41)).results).contains(
+            ValidationError(dataTrace().tag("test" to "favorite number is 42", "assertion" to "favorite number == 42"), "Fail: favorite number == 42", "41 == 42")
+        )
     }
 
     @Test
@@ -279,6 +285,12 @@ internal class BaleenTest {
         }
 
         assertThat(dataDesc.validate(dataOf("favorite number" to 42))).isValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 42)).results).contains(
+            ValidationInfo(dataTrace().tag("test" to "favorite number is 42", "assertion" to "favorite number == 42"), "Pass: favorite number == 42", "42 == 42")
+        )
         assertThat(dataDesc.validate(dataOf("favorite number" to 41))).isNotValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 41)).results).contains(
+            ValidationError(dataTrace().tag("test" to "favorite number is 42", "assertion" to "favorite number == 42"), "Fail: favorite number == 42", "41 == 42")
+        )
     }
 }

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/BaleenTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/BaleenTest.kt
@@ -4,6 +4,7 @@ import com.shoprunner.baleen.Baleen.describeAs
 import com.shoprunner.baleen.TestHelper.dataOf
 import com.shoprunner.baleen.ValidationAssert.Companion.assertThat
 import com.shoprunner.baleen.types.AllowsNull
+import com.shoprunner.baleen.types.IntType
 import com.shoprunner.baleen.types.StringType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -251,6 +252,32 @@ internal class BaleenTest {
         }
 
         assertThat(dataDesc.validate(dataOf<String>())).isNotValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 42))).isValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 41))).isNotValid()
+    }
+
+    @Test
+    fun `junit style attribute test`() {
+        val dataDesc = "FavoriteNumber".describeAs {
+            "favorite number".type(IntType()).describe {
+                test("favorite number is 42") { data ->
+                    assertEquals("favorite number == 42", data.getAsInt("favorite number"), 42)
+                }
+            }
+        }
+
+        assertThat(dataDesc.validate(dataOf("favorite number" to 42))).isValid()
+        assertThat(dataDesc.validate(dataOf("favorite number" to 41))).isNotValid()
+    }
+
+    @Test
+    fun `junit style test`() {
+        val dataDesc = "FavoriteNumber".describeAs {
+            test("favorite number is 42") { data ->
+                assertEquals("favorite number == 42", data.getAsInt("favorite number"), 42)
+            }
+        }
+
         assertThat(dataDesc.validate(dataOf("favorite number" to 42))).isValid()
         assertThat(dataDesc.validate(dataOf("favorite number" to 41))).isNotValid()
     }


### PR DESCRIPTION
In #218, I propose making test writing more familiar and use tests and assertions that automatically update data trace with tags that say where the test comes from.

```kotlin
// At the attribute level
val dataDesc = "FavoriteNumber".describeAs {
    "favorite number".type(IntType()).describe {
        test("favorite number is 42") { data ->
            // Tradition assert* style
            assertEquals("favorite number == 42", data.getAsInt("favorite number"), 42)

            // Even better assertThat style
            assertThat(data).hasAttribute("favorite number") { it.isEqualTo(42) }
        }
    }
}

// At the data description level
val dataDesc = "FavoriteNumber".describeAs {
    test("favorite number is 42") { data ->
        // Tradition assert* style
        assertEquals("favorite number == 42", data.getAsInt("favorite number"), 42)

        // Even better assertThat style
        assertThat(data).hasAttribute("favorite number") { it.isEqualTo(42) }
    }
}
```

Each test adds a tag for `"test" to testName` and each assertion adds a tag `"assertion" to assertionMessage` to the datatrace to make it easy to find later on.  Each assertion returns either a ValidationError when it fails or a ValidationInfo when it passes.

in addition, I added get functions in `Data` for casting to certain types to make it to write tests. These throw IllegalArgumentExceptions and have hard failures that will cause the tests to exit opposed to soft ValidationErrors.

TODO:
* ~Tests for Assert class~
* Tests for new Data functions
* Update docs