### PR TITLE
Bugfix: AssertThat<Any?>.isA should compile on non-null receivers

### DIFF
--- a/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
+++ b/baleen/src/main/kotlin/com/shoprunner/baleen/Assertions.kt
@@ -536,7 +536,7 @@ class Assertions(val dataTrace: DataTrace) {
         return assertTrue(message, value is T, "$value is a ${value?.let { it::class.qualifiedName } ?: "${T::class.qualifiedName}?"}")
     }
 
-    inline fun <reified T : Any?> AssertThat<Any?>.isA(message: String = "is a ${T::class.qualifiedName}"): AssertThat<T> {
+    inline fun <reified T : Any?> AssertThat<*>.isA(message: String = "is a ${T::class.qualifiedName}"): AssertThat<T> {
         return when (this) {
             is AssertThatValue ->
                 if (this.typedActual is T) {

--- a/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
+++ b/baleen/src/test/kotlin/com/shoprunner/baleen/AssertThatTest.kt
@@ -780,6 +780,7 @@ internal class AssertThatTest {
         with(Assertions(dataTrace())) {
             assertThat(data).hasAttribute("valueStr") { it.isA<String>() }
             assertThat(data).hasAttribute("valueStr") { it.isA<Int>() }
+            assertThat(data).hasAttribute("valueStr") { it.isNullOr { x -> x.isA<Double>() } }
             assertThat(data).hasAttribute("valueNull") { it.isA<String>() }
             assertThat(data).hasAttribute("valueNull") { it.isA<String?>() }
 
@@ -788,6 +789,7 @@ internal class AssertThatTest {
             junitAssertThat(results).contains(
                 ValidationInfo(dataTrace().tag("assertion" to "data[valueStr] is a kotlin.String"), "Pass: data[valueStr] is a kotlin.String", "Hello World"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueStr] is a kotlin.Int"), "Fail: data[valueStr] is a kotlin.Int", "Hello World"),
+                ValidationError(dataTrace().tag("assertion" to "data[valueStr] is a kotlin.Double"), "Fail: data[valueStr] is a kotlin.Double", "Hello World"),
                 ValidationError(dataTrace().tag("assertion" to "data[valueNull] is a kotlin.String"), "Fail: data[valueNull] is a kotlin.String", null),
                 ValidationInfo(dataTrace().tag("assertion" to "data[valueNull] is a kotlin.String"), "Pass: data[valueNull] is a kotlin.String", null),
             )


### PR DESCRIPTION
This styile of code should compile but wasn't

```kotlin
assertThat(data).hasAttribute("valueStr") { it.isNullOr { x -> x.isA<Double>() } }
```

Moving to `AssertThat<*>.isA` receiver allows the above to compile